### PR TITLE
Reconstruct source from stable v1.0.0 architecture

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Historical v1.0.0 forensic helper tests
         run: python3 tests/test_v1_forensics.py
+
+      - name: PHU r11 donor delta helper tests
+        run: python3 tests/test_phu_donor_compare.py

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: etaHEN wrapper test
         run: python3 tests/test_plugin_wrapper.py
+
+      - name: Historical v1.0.0 forensic helper tests
+        run: python3 tests/test_v1_forensics.py

--- a/.github/workflows/ps5-source-build.yml
+++ b/.github/workflows/ps5-source-build.yml
@@ -46,6 +46,7 @@ jobs:
             dist/Common_FPS_PS5_v1.1.0.elf
             dist/Common_FPS_PS5_etaHEN_v1.1.0.plugin
             dist/Common_FPS_ShellUI_v1.1.0.elf
+            dist/Common_FPS_PS5_v1_parity_probe_FW960.elf
             dist/SHA256SUMS.txt
             RESOLVED_BUILD_DEPENDENCIES.txt
           if-no-files-found: error

--- a/.github/workflows/ps5-source-build.yml
+++ b/.github/workflows/ps5-source-build.yml
@@ -2,6 +2,9 @@ name: PS5 Source Build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
   push:
     tags:
       - "v1.1.0-rc*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,4 +102,14 @@ if(COMMON_FPS_BUILD_TESTS)
         NAME common_fps_v1_loader_contract_tests
         COMMAND common_fps_v1_loader_contract_tests
     )
+
+    add_executable(
+        common_fps_v1_stable_overlay_tests
+        tests/test_v1_stable_overlay.cpp
+    )
+    target_include_directories(common_fps_v1_stable_overlay_tests PRIVATE include)
+    add_test(
+        NAME common_fps_v1_stable_overlay_tests
+        COMMAND common_fps_v1_stable_overlay_tests
+    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,12 @@ add_library(common_fps_v1_reconstruction STATIC
     src/reconstruction/v1_stable_hook_state.cpp
     src/reconstruction/v1_stable_render_loop.cpp
     src/reconstruction/v1_stable_sampler.cpp
+    integration/loader/v1_loader_contract.cpp
 )
-target_include_directories(common_fps_v1_reconstruction PUBLIC include)
+target_include_directories(
+    common_fps_v1_reconstruction
+    PUBLIC include integration/loader
+)
 target_compile_options(common_fps_v1_reconstruction PRIVATE -Wall -Wextra -Wpedantic)
 
 option(COMMON_FPS_BUILD_TESTS "Build host tests" ON)
@@ -31,31 +35,24 @@ option(COMMON_FPS_BUILD_TESTS "Build host tests" ON)
 if(COMMON_FPS_BUILD_TESTS)
     enable_testing()
 
-    add_executable(common_fps_tests
-        tests/test_core.cpp
-    )
+    add_executable(common_fps_tests tests/test_core.cpp)
     target_link_libraries(common_fps_tests PRIVATE common_fps_core)
     add_test(NAME common_fps_tests COMMAND common_fps_tests)
 
-    add_executable(common_fps_v1_parity_tests
-        tests/test_v1_parity.cpp
-    )
+    add_executable(common_fps_v1_parity_tests tests/test_v1_parity.cpp)
     target_link_libraries(common_fps_v1_parity_tests PRIVATE common_fps_core)
     add_test(NAME common_fps_v1_parity_tests COMMAND common_fps_v1_parity_tests)
 
-    add_executable(common_fps_autoload_tests
-        tests/test_autoload_guard.cpp
-    )
+    add_executable(common_fps_autoload_tests tests/test_autoload_guard.cpp)
     target_link_libraries(common_fps_autoload_tests PRIVATE common_fps_core)
     add_test(NAME common_fps_autoload_tests COMMAND common_fps_autoload_tests)
 
-    add_executable(common_fps_v1_stable_wire_tests
-        tests/test_v1_stable_wire.cpp
-    )
+    add_executable(common_fps_v1_stable_wire_tests tests/test_v1_stable_wire.cpp)
     target_include_directories(common_fps_v1_stable_wire_tests PRIVATE include)
     add_test(NAME common_fps_v1_stable_wire_tests COMMAND common_fps_v1_stable_wire_tests)
 
-    add_executable(common_fps_v1_stable_hook_state_tests
+    add_executable(
+        common_fps_v1_stable_hook_state_tests
         tests/test_v1_stable_hook_state.cpp
     )
     target_link_libraries(
@@ -67,7 +64,8 @@ if(COMMON_FPS_BUILD_TESTS)
         COMMAND common_fps_v1_stable_hook_state_tests
     )
 
-    add_executable(common_fps_v1_stable_render_loop_tests
+    add_executable(
+        common_fps_v1_stable_render_loop_tests
         tests/test_v1_stable_render_loop.cpp
     )
     target_link_libraries(
@@ -79,7 +77,8 @@ if(COMMON_FPS_BUILD_TESTS)
         COMMAND common_fps_v1_stable_render_loop_tests
     )
 
-    add_executable(common_fps_v1_stable_sampler_tests
+    add_executable(
+        common_fps_v1_stable_sampler_tests
         tests/test_v1_stable_sampler.cpp
     )
     target_link_libraries(
@@ -89,5 +88,18 @@ if(COMMON_FPS_BUILD_TESTS)
     add_test(
         NAME common_fps_v1_stable_sampler_tests
         COMMAND common_fps_v1_stable_sampler_tests
+    )
+
+    add_executable(
+        common_fps_v1_loader_contract_tests
+        tests/test_v1_loader_contract.cpp
+    )
+    target_link_libraries(
+        common_fps_v1_loader_contract_tests
+        PRIVATE common_fps_v1_reconstruction
+    )
+    add_test(
+        NAME common_fps_v1_loader_contract_tests
+        COMMAND common_fps_v1_loader_contract_tests
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(common_fps_v1_reconstruction STATIC
     src/reconstruction/v1_stable_render_loop.cpp
     src/reconstruction/v1_stable_sampler.cpp
     src/reconstruction/v1_stable_controller.cpp
+    src/reconstruction/v1_stable_memory.cpp
     integration/loader/v1_loader_contract.cpp
 )
 target_include_directories(
@@ -51,6 +52,10 @@ if(COMMON_FPS_BUILD_TESTS)
     add_executable(common_fps_v1_stable_wire_tests tests/test_v1_stable_wire.cpp)
     target_include_directories(common_fps_v1_stable_wire_tests PRIVATE include)
     add_test(NAME common_fps_v1_stable_wire_tests COMMAND common_fps_v1_stable_wire_tests)
+
+    add_executable(common_fps_v1_stable_memory_tests tests/test_v1_stable_memory.cpp)
+    target_link_libraries(common_fps_v1_stable_memory_tests PRIVATE common_fps_v1_reconstruction)
+    add_test(NAME common_fps_v1_stable_memory_tests COMMAND common_fps_v1_stable_memory_tests)
 
     add_executable(common_fps_v1_stable_hook_state_tests tests/test_v1_stable_hook_state.cpp)
     target_link_libraries(common_fps_v1_stable_hook_state_tests PRIVATE common_fps_v1_reconstruction)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,3 +48,12 @@ if(COMMON_FPS_BUILD_TESTS)
     target_link_libraries(common_fps_autoload_tests PRIVATE common_fps_core)
     add_test(NAME common_fps_autoload_tests COMMAND common_fps_autoload_tests)
 endif()
+
+
+if(COMMON_FPS_BUILD_TESTS)
+    add_executable(common_fps_v1_stable_wire_tests
+        tests/test_v1_stable_wire.cpp
+    )
+    target_include_directories(common_fps_v1_stable_wire_tests PRIVATE include)
+    add_test(NAME common_fps_v1_stable_wire_tests COMMAND common_fps_v1_stable_wire_tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,12 @@ add_library(common_fps_core STATIC
 target_include_directories(common_fps_core PUBLIC include)
 target_compile_options(common_fps_core PRIVATE -Wall -Wextra -Wpedantic)
 
+add_library(common_fps_v1_reconstruction STATIC
+    src/reconstruction/v1_stable_hook_state.cpp
+)
+target_include_directories(common_fps_v1_reconstruction PUBLIC include)
+target_compile_options(common_fps_v1_reconstruction PRIVATE -Wall -Wextra -Wpedantic)
+
 option(COMMON_FPS_BUILD_TESTS "Build host tests" ON)
 
 if(COMMON_FPS_BUILD_TESTS)
@@ -56,4 +62,19 @@ if(COMMON_FPS_BUILD_TESTS)
     )
     target_include_directories(common_fps_v1_stable_wire_tests PRIVATE include)
     add_test(NAME common_fps_v1_stable_wire_tests COMMAND common_fps_v1_stable_wire_tests)
+endif()
+
+
+if(COMMON_FPS_BUILD_TESTS)
+    add_executable(common_fps_v1_stable_hook_state_tests
+        tests/test_v1_stable_hook_state.cpp
+    )
+    target_link_libraries(
+        common_fps_v1_stable_hook_state_tests
+        PRIVATE common_fps_v1_reconstruction
+    )
+    add_test(
+        NAME common_fps_v1_stable_hook_state_tests
+        COMMAND common_fps_v1_stable_hook_state_tests
+    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(common_fps_v1_reconstruction STATIC
     src/reconstruction/v1_stable_hook_state.cpp
     src/reconstruction/v1_stable_render_loop.cpp
     src/reconstruction/v1_stable_sampler.cpp
+    src/reconstruction/v1_stable_controller.cpp
     integration/loader/v1_loader_contract.cpp
 )
 target_include_directories(
@@ -51,65 +52,27 @@ if(COMMON_FPS_BUILD_TESTS)
     target_include_directories(common_fps_v1_stable_wire_tests PRIVATE include)
     add_test(NAME common_fps_v1_stable_wire_tests COMMAND common_fps_v1_stable_wire_tests)
 
-    add_executable(
-        common_fps_v1_stable_hook_state_tests
-        tests/test_v1_stable_hook_state.cpp
-    )
-    target_link_libraries(
-        common_fps_v1_stable_hook_state_tests
-        PRIVATE common_fps_v1_reconstruction
-    )
-    add_test(
-        NAME common_fps_v1_stable_hook_state_tests
-        COMMAND common_fps_v1_stable_hook_state_tests
-    )
+    add_executable(common_fps_v1_stable_hook_state_tests tests/test_v1_stable_hook_state.cpp)
+    target_link_libraries(common_fps_v1_stable_hook_state_tests PRIVATE common_fps_v1_reconstruction)
+    add_test(NAME common_fps_v1_stable_hook_state_tests COMMAND common_fps_v1_stable_hook_state_tests)
 
-    add_executable(
-        common_fps_v1_stable_render_loop_tests
-        tests/test_v1_stable_render_loop.cpp
-    )
-    target_link_libraries(
-        common_fps_v1_stable_render_loop_tests
-        PRIVATE common_fps_v1_reconstruction
-    )
-    add_test(
-        NAME common_fps_v1_stable_render_loop_tests
-        COMMAND common_fps_v1_stable_render_loop_tests
-    )
+    add_executable(common_fps_v1_stable_render_loop_tests tests/test_v1_stable_render_loop.cpp)
+    target_link_libraries(common_fps_v1_stable_render_loop_tests PRIVATE common_fps_v1_reconstruction)
+    add_test(NAME common_fps_v1_stable_render_loop_tests COMMAND common_fps_v1_stable_render_loop_tests)
 
-    add_executable(
-        common_fps_v1_stable_sampler_tests
-        tests/test_v1_stable_sampler.cpp
-    )
-    target_link_libraries(
-        common_fps_v1_stable_sampler_tests
-        PRIVATE common_fps_v1_reconstruction
-    )
-    add_test(
-        NAME common_fps_v1_stable_sampler_tests
-        COMMAND common_fps_v1_stable_sampler_tests
-    )
+    add_executable(common_fps_v1_stable_sampler_tests tests/test_v1_stable_sampler.cpp)
+    target_link_libraries(common_fps_v1_stable_sampler_tests PRIVATE common_fps_v1_reconstruction)
+    add_test(NAME common_fps_v1_stable_sampler_tests COMMAND common_fps_v1_stable_sampler_tests)
 
-    add_executable(
-        common_fps_v1_loader_contract_tests
-        tests/test_v1_loader_contract.cpp
-    )
-    target_link_libraries(
-        common_fps_v1_loader_contract_tests
-        PRIVATE common_fps_v1_reconstruction
-    )
-    add_test(
-        NAME common_fps_v1_loader_contract_tests
-        COMMAND common_fps_v1_loader_contract_tests
-    )
+    add_executable(common_fps_v1_loader_contract_tests tests/test_v1_loader_contract.cpp)
+    target_link_libraries(common_fps_v1_loader_contract_tests PRIVATE common_fps_v1_reconstruction)
+    add_test(NAME common_fps_v1_loader_contract_tests COMMAND common_fps_v1_loader_contract_tests)
 
-    add_executable(
-        common_fps_v1_stable_overlay_tests
-        tests/test_v1_stable_overlay.cpp
-    )
+    add_executable(common_fps_v1_stable_overlay_tests tests/test_v1_stable_overlay.cpp)
     target_include_directories(common_fps_v1_stable_overlay_tests PRIVATE include)
-    add_test(
-        NAME common_fps_v1_stable_overlay_tests
-        COMMAND common_fps_v1_stable_overlay_tests
-    )
+    add_test(NAME common_fps_v1_stable_overlay_tests COMMAND common_fps_v1_stable_overlay_tests)
+
+    add_executable(common_fps_v1_stable_controller_tests tests/test_v1_stable_controller.cpp)
+    target_link_libraries(common_fps_v1_stable_controller_tests PRIVATE common_fps_v1_reconstruction)
+    add_test(NAME common_fps_v1_stable_controller_tests COMMAND common_fps_v1_stable_controller_tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ target_compile_options(common_fps_core PRIVATE -Wall -Wextra -Wpedantic)
 add_library(common_fps_v1_reconstruction STATIC
     src/reconstruction/v1_stable_hook_state.cpp
     src/reconstruction/v1_stable_render_loop.cpp
+    src/reconstruction/v1_stable_sampler.cpp
 )
 target_include_directories(common_fps_v1_reconstruction PUBLIC include)
 target_compile_options(common_fps_v1_reconstruction PRIVATE -Wall -Wextra -Wpedantic)
@@ -33,40 +34,27 @@ if(COMMON_FPS_BUILD_TESTS)
     add_executable(common_fps_tests
         tests/test_core.cpp
     )
-
     target_link_libraries(common_fps_tests PRIVATE common_fps_core)
     add_test(NAME common_fps_tests COMMAND common_fps_tests)
-endif()
 
-
-if(COMMON_FPS_BUILD_TESTS)
     add_executable(common_fps_v1_parity_tests
         tests/test_v1_parity.cpp
     )
     target_link_libraries(common_fps_v1_parity_tests PRIVATE common_fps_core)
     add_test(NAME common_fps_v1_parity_tests COMMAND common_fps_v1_parity_tests)
-endif()
 
-
-if(COMMON_FPS_BUILD_TESTS)
     add_executable(common_fps_autoload_tests
         tests/test_autoload_guard.cpp
     )
     target_link_libraries(common_fps_autoload_tests PRIVATE common_fps_core)
     add_test(NAME common_fps_autoload_tests COMMAND common_fps_autoload_tests)
-endif()
 
-
-if(COMMON_FPS_BUILD_TESTS)
     add_executable(common_fps_v1_stable_wire_tests
         tests/test_v1_stable_wire.cpp
     )
     target_include_directories(common_fps_v1_stable_wire_tests PRIVATE include)
     add_test(NAME common_fps_v1_stable_wire_tests COMMAND common_fps_v1_stable_wire_tests)
-endif()
 
-
-if(COMMON_FPS_BUILD_TESTS)
     add_executable(common_fps_v1_stable_hook_state_tests
         tests/test_v1_stable_hook_state.cpp
     )
@@ -89,5 +77,17 @@ if(COMMON_FPS_BUILD_TESTS)
     add_test(
         NAME common_fps_v1_stable_render_loop_tests
         COMMAND common_fps_v1_stable_render_loop_tests
+    )
+
+    add_executable(common_fps_v1_stable_sampler_tests
+        tests/test_v1_stable_sampler.cpp
+    )
+    target_link_libraries(
+        common_fps_v1_stable_sampler_tests
+        PRIVATE common_fps_v1_reconstruction
+    )
+    add_test(
+        NAME common_fps_v1_stable_sampler_tests
+        COMMAND common_fps_v1_stable_sampler_tests
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ target_compile_options(common_fps_core PRIVATE -Wall -Wextra -Wpedantic)
 
 add_library(common_fps_v1_reconstruction STATIC
     src/reconstruction/v1_stable_hook_state.cpp
+    src/reconstruction/v1_stable_render_loop.cpp
 )
 target_include_directories(common_fps_v1_reconstruction PUBLIC include)
 target_compile_options(common_fps_v1_reconstruction PRIVATE -Wall -Wextra -Wpedantic)
@@ -76,5 +77,17 @@ if(COMMON_FPS_BUILD_TESTS)
     add_test(
         NAME common_fps_v1_stable_hook_state_tests
         COMMAND common_fps_v1_stable_hook_state_tests
+    )
+
+    add_executable(common_fps_v1_stable_render_loop_tests
+        tests/test_v1_stable_render_loop.cpp
+    )
+    target_link_libraries(
+        common_fps_v1_stable_render_loop_tests
+        PRIVATE common_fps_v1_reconstruction
+    )
+    add_test(
+        NAME common_fps_v1_stable_render_loop_tests
+        COMMAND common_fps_v1_stable_render_loop_tests
     )
 endif()

--- a/docs/HARDWARE_TEST_PLAN_FW960.md
+++ b/docs/HARDWARE_TEST_PLAN_FW960.md
@@ -1,87 +1,32 @@
-# FW 9.60 hardware acceptance plan
+# FW 9.60 hardware test plan
 
-Stable reference: public Common FPS v1.0.0.
+The hardware-stable historical v1.0.0 remains the behavioral baseline.
 
-## A. Manual activation baseline
+## Stable-v1 reconstruction order
 
-1. Boot/jailbreak.
-2. Activate etaHEN.
-3. Wait until Home/ShellUI is fully usable.
-4. Manually Run Common FPS.
+1. Reproduce the historical sampler and process-memory read path.
+2. Validate it independently with a bounded diagnostic ELF.
+3. Reconstruct the historical renderer/loader contract.
+4. Validate manual-run parity.
+5. Only then add autoload readiness around the proven initialization.
 
-Expected:
-- fast Run;
-- no debug spam;
-- integer FPS;
-- no KP.
+## Parity probe v2
 
-## B. Autoload — new v1.1.0 release blocker
+`Common_FPS_PS5_v1_parity_probe_FW960.elf` is a read-only diagnostic target. It installs no ShellUI renderer, no hook, and no autoload behavior.
 
-Enable Common FPS autoload and cold boot through the normal etaHEN flow.
+Run it manually while a game is already active. Every completed stage is flushed to:
 
-Expected:
-- no error on the first game launch;
-- no KP;
-- FPS appears without manual Stop/Run;
-- etaHEN "enabled" state corresponds to a live renderer.
+`/data/CommonFPS_v1_probe.log`
 
-Repeat at least five cold-start cycles.
+Stages:
 
-## C. Early game launch race
+- `S0` diagnostic `main()` entered
+- `S1` `eboot.bin` process found
+- `S2` `libSceVideoOut.sprx` found
+- `S3` PHU-style FW 9.60 DMAP table read completed
+- `S4` stable sampler resolved the VideoOut counter
+- `S5` real FPS sample obtained
 
-With autoload enabled, launch a game as soon as the Home UI becomes available.
+If screen notifications are unavailable, the file log remains authoritative. If the file is not created at all, investigate the standalone ELF launch/entry-point path before changing the sampler.
 
-Expected:
-- guard may delay FPS appearance;
-- game must still launch normally;
-- plugin must not touch the game until renderer/runtime readiness is confirmed;
-- FPS appears automatically once safe.
-
-## D. 30/60 behavior
-
-Expected:
-- quality mode ~ `FPS: 30`;
-- performance mode ~ `FPS: 60`;
-- no decimal places.
-
-## E. Position regression
-
-Run at least five minutes.
-
-Expected:
-- bottom-left default;
-- font size 26;
-- no horizontal drift;
-- no disappearing counter.
-
-## F. Game lifecycle
-
-Repeat at least five cycles:
-
-```text
-Game A -> close -> Home -> Game B
-```
-
-Expected:
-- no second Run;
-- new PID discovered;
-- no stale module address;
-- no KP.
-
-## G. Renderer self-heal
-
-If practical, stop/restart the renderer-side component or recreate ShellUI.
-
-Expected:
-- worker does not remain falsely "enabled but dead";
-- guard retries and restores FPS;
-- no duplicate labels.
-
-## H. Standalone ELF
-
-The standalone ELF must remain independent of etaHEN's built-in FPS setting.
-
-## Promotion rule
-
-Do not replace public v1.0.0 until all manual, autoload, lifecycle and
-standalone tests pass on FW 9.60.
+Do not install this probe as an etaHEN plugin and do not put it in Autoload.

--- a/docs/PHU_V1_14_25_R11_DONOR_DELTA.md
+++ b/docs/PHU_V1_14_25_R11_DONOR_DELTA.md
@@ -1,0 +1,185 @@
+# PHU v1.14.25-r11 -> Common FPS v1.0.0 donor delta
+
+This document records the binary relationship between the public PHU Games Tools
+v1.14.25-r11 payload and the hardware-stable Common FPS v1.0.0 payload.
+
+The purpose is source reconstruction. The PHU release archive is **not** treated
+as corresponding source and is not committed to this repository.
+
+## Inputs
+
+PHU Games Tools v1.14.25-r11:
+
+```text
+phu_overlay.elf
+size:   1,555,144 bytes
+SHA256: 8e20deefb9100705be8352dc6acb47241c6a044b93dc3f578f93c424789b2622
+Build ID: 4fcee90fdb9656b3ff5026338c0846de
+```
+
+Common FPS v1.0.0 payload ELF:
+
+```text
+size:   1,555,144 bytes
+SHA256: 6a66da88a99fa8757bf5c649e388d777a10768cd444d9f4cf82649e4592e292c
+Build ID: 4fcee90fdb9656b3ff5026338c0846de
+```
+
+The two outer ELFs therefore retain the same image layout and the same Build ID.
+The PHU ELF is not stripped and preserves the function / compilation-unit map
+needed to identify the Common FPS modifications.
+
+## Outer payload delta
+
+Comparing the allocatable outer `.text` section shows:
+
+```text
+changed bytes: 1,350
+changed runs:  45
+```
+
+Only three original functions contain changed text bytes:
+
+```text
+main
+probe_main_entry
+elfldr_load
+```
+
+This is a major reconstruction constraint: the stable Common FPS controller did
+not require a new payload architecture. It is a very small delta over the exact
+PHU r11 controller layout.
+
+Recovered interpretation from the historical v0.27/v0.28 hardware tests:
+
+- `main`: asynchronous `fork()` entry; parent returns immediately and child runs
+  the proven initialization;
+- `probe_main_entry`: Common-FPS-only lifecycle / VideoOut sampling path;
+- `elfldr_load`: Trace Continue behavior required to keep one ShellUI loader
+  session alive while local ELF preparation occurs.
+
+The corresponding-source reconstruction should reproduce these behaviors in
+normal source instead of preserving the historical binary patches.
+
+## Embedded ShellUI renderer
+
+Both payloads contain an embedded renderer at the same symbol range:
+
+```text
+_binary_libphu_overlay_so_start
+_binary_libphu_overlay_so_end
+size: 260,248 bytes
+```
+
+PHU r11 renderer:
+
+```text
+SHA256:   8d1490ac7d1ba589044108675e29a1d3cc05a0a946556d52aeb502d114ea7eca
+Build ID: c6ee2731d817d85466e9fbef5be7de79
+```
+
+Common FPS v1.0.0 renderer:
+
+```text
+SHA256:   3640cbcaf907bc900e257503b3c8922fdbc129c492a76a2348fd75c84f68b91c
+Build ID: c6ee2731d817d85466e9fbef5be7de79
+```
+
+The PHU renderer is unstripped and contains symbol + DWARF information. The
+Common FPS copy is stripped, but both retain the same runtime section layout.
+
+Most importantly, comparing only allocatable renderer sections gives:
+
+```text
+.text   : 120 changed bytes
+.rodata :  25 changed bytes
+```
+
+The changed renderer text maps only to:
+
+```text
+elf_main
+read_cfg_v13
+phu_set_fps_text_raw
+phu_create_fps_label
+install_onrender_hook
+OnRender_Hook
+```
+
+This proves that the hardware-stable Common FPS renderer is a minimal derivative
+of the PHU r11 renderer rather than the independent ShellUI renderer attempted
+in the rejected Stage B/B2/B3 branches.
+
+## Renderer source map recovered from PHU DWARF
+
+The unstripped donor renderer preserves these compilation units:
+
+```text
+source/main.cpp
+source/mono_glue.cpp
+source/hook.cpp
+source/Detour.cpp
+source/hde64.cpp
+source/phu_overlay_kernel_rw.c
+source/phu_shellui_stubs.c
+source/phu_fw_offsets.c
+source/phu_kstuff_flip.c
+source/mman.c
+source/strcasecmp.c
+```
+
+The DWARF compilation directory is:
+
+```text
+D:/dump/Claude Code/PHU Overlay/payload/shellui_overlay
+```
+
+High-value named functions include:
+
+```text
+mono_glue_init
+mono_glue_resolve_scene
+phu_set_fps_text_raw
+phu_create_fps_label
+phu_set_fps_text
+phu_remove_fps_label
+install_onrender_hook
+OnRender_Hook
+phu_check_running_on_main_thread_stub
+patch_main_thread_check
+```
+
+These names and line tables provide the reconstruction map for a readable,
+source-built renderer.
+
+## Reconstruction rule
+
+Do not reintroduce the rejected independent ShellUI design.
+
+The next source-built hardware candidate must first reproduce the stable manual
+v1.0.0 contract:
+
+```text
+PHU-r11-compatible loader contract
+  + minimal Common FPS controller delta
+  + minimal Common FPS renderer delta
+  + full payload_args / Scene readiness / Trace Continue behavior
+  + async fork entry
+```
+
+Only after manual hardware parity is restored should etaHEN autoload readiness
+be added around that same initialization path.
+
+## Local comparison tool
+
+For developers who possess the historical donor ELF and stable Common FPS file:
+
+```bash
+python3 tools/compare_phu_r11_donor.py \
+  /path/to/phu_overlay.elf \
+  /path/to/Common_FPS_PS5_etaHEN_v1.0.0.plugin \
+  --json donor_delta.json
+```
+
+The donor and historical release binaries are intentionally not committed to the
+source tree.

--- a/docs/SOURCE_STATUS.md
+++ b/docs/SOURCE_STATUS.md
@@ -1,33 +1,83 @@
 # Source status
 
-## v1.1.0-rc1
-
-This repository is the clean source-built successor branch.
-
-The source-built path contains no historical PHU renderer ELF/SO blob.
-
-Common FPS-owned core, lifecycle, configuration, sampler and Safe Autoload
-logic are published directly as source.
-
-PS5-specific integration is built against pinned/open GPL upstream source.
-
 ## Hardware-stable baseline
 
-The existing public `v1.0.0` binary remains the hardware-stable baseline for
-manual activation on FW 9.60.
+The public `v1.0.0` binary remains the hardware-stable baseline for manual
+activation on FW 9.60.
 
-Its historical binary was not originally produced from this clean source tree,
-so this repository does not pretend otherwise.
+The released etaHEN plugin is the historical internal v0.28b build:
 
-## Promotion to v1.1.0 stable
+```text
+plugin SHA-256  f1240511bfe3cb17a3db6f4d099cf3cd69be678d10901425a7b33911265195e1
+payload SHA-256 6a66da88a99fa8757bf5c649e388d777a10768cd444d9f4cf82649e4592e292c
+wrapper          CFPS00020 / 0.28
+```
 
-The RC becomes stable only when:
+Its historical binary was not originally produced from the current clean
+source tree, so this repository does not pretend otherwise.
+
+See `docs/V1_0_0_BINARY_FORENSICS.md` for the recovered module/symbol map and
+embedded-renderer evidence.
+
+## Current source reconstruction line
+
+The active development direction is now **stable-architecture source
+reconstruction**.
+
+The goal is to publish maintainable source that reproduces the real v1.0.0
+runtime contract before adding any new behavior:
+
+- async `fork()` entry;
+- stable SceShellUI wait/inject path;
+- Trace-Continue loader session;
+- full `elfldr_payload_args()` side effects;
+- Scene readiness;
+- read-only PS4/PS5 VideoOut FPS sampling;
+- game-switch lifecycle;
+- the proven bottom-left renderer behavior.
+
+The historical stable ELF is not stripped and exposes enough symbol/source-unit
+information to guide this reconstruction. The historical binary itself is not
+required in the source tree; `tools/analyze_v1_stable.py` performs local
+read-only verification when a user supplies a copy.
+
+## Rejected source-renderer experiments
+
+The Stage B, B2 and B3 branches are hardware rejected and must not be used as
+parity targets. They attempted to introduce/chainsaw another live ShellUI
+`Application.Update` hook and caused regressions including missing Common FPS,
+Stop/Run kernel panic and broader etaHEN/YBJB instability.
+
+The reconstruction must not repeat that design.
+
+## Autoload policy
+
+Autoload is still a release goal, but it is no longer allowed to drive a
+renderer redesign.
+
+The correct order is:
+
+1. source-built manual-run build reaches v1.0.0 hardware parity;
+2. PS4 + PS5 and Game A -> Home -> Game B pass without KP;
+3. only then add a conservative readiness gate **before the same proven stable
+   initialization**;
+4. validate etaHEN Autoload separately;
+5. investigate FW 7.60 `FPS: loading` as a separate compatibility issue.
+
+## Promotion to a new stable source release
+
+A new source release becomes stable only when:
 
 1. GitHub `Host Source Tests` passes;
 2. GitHub `PS5 Source Build` passes;
-3. source-built ELF/plugin artifacts are produced;
-4. FW 9.60 manual-start testing passes;
-5. FW 9.60 etaHEN autoload testing passes;
-6. repeated game-switch lifecycle testing passes without KP.
+3. source-built ELF/plugin artifacts are produced without historical binary
+   blobs being passed off as source;
+4. FW 9.60 manual-start behavior matches v1.0.0;
+5. PS4 and PS5 real FPS are verified;
+6. repeated game-switch lifecycle testing passes without KP;
+7. etaHEN Autoload passes without manual Stop/Run;
+8. source/license/third-party notices accurately describe every reused upstream
+   component.
 
-Until then the correct public version label is `v1.1.0-rc1`.
+Until those conditions are met, the historical public `v1.0.0` remains the
+stable hardware release.

--- a/docs/V1_0_0_BINARY_FORENSICS.md
+++ b/docs/V1_0_0_BINARY_FORENSICS.md
@@ -1,0 +1,205 @@
+# Historical v1.0.0 binary forensics
+
+This document records facts recovered from the hardware-stable Common FPS
+v1.0.0 release. It exists to guide a source reconstruction that matches the
+real working architecture instead of inventing a new renderer path.
+
+## Golden hashes
+
+Public etaHEN plugin:
+
+```text
+Common_FPS_PS5_etaHEN_v1.0.0.plugin
+SHA-256 f1240511bfe3cb17a3db6f4d099cf3cd69be678d10901425a7b33911265195e1
+```
+
+The etaHEN wrapper is 29 bytes:
+
+```text
+etaHEN_PLUGIN\0CFPS00020\00.28\0
+```
+
+The embedded controller payload is therefore the historical internal v0.28b
+ELF:
+
+```text
+SHA-256 6a66da88a99fa8757bf5c649e388d777a10768cd444d9f4cf82649e4592e292c
+```
+
+The stable ELF is not stripped. It retains `.symtab` and enough compilation
+unit names to recover the original architecture.
+
+## Recovered project compilation units
+
+The stable controller contains `STT_FILE` records for the following
+project-specific units in addition to SDK/libc runtime objects:
+
+```text
+dbg.cpp
+hijacker.cpp
+kernel.cpp
+notify.cpp
+offsets_v940.cpp
+main.cpp
+hook_vout.cpp
+proc_rw_v940.cpp
+shm_writer.cpp
+phu_patcher.cpp
+phu_cheat_engine.cpp
+phu_menu_shm.cpp
+phu_recovery.cpp
+videoout_ioctl.cpp
+videoout_dcb_ring.cpp
+videoout_dcb_global.cpp
+elfldr.c
+injector.c
+notify.c
+proc.c
+pt.c
+ucred.c
+phu_notify.c
+phu_config.c
+phu_stats.c
+phu_fw_offsets.c
+phu_kstuff_flip.c
+phu_kstuff_ctrl.c
+phu_klog_mirror.c
+phu_patch_types.c
+phu_xml_parser.c
+phu_json_parser.c
+phu_shn_parser.c
+phu_mc4_parser.c
+phu_mc4_aes.c
+phu_mc4_base64.c
+phu_appver.c
+```
+
+This proves that the stable release was built from a PHU-derived payload/probe
+source tree plus the Common FPS-specific patches. The current clean C++ rewrite
+must therefore not be described as byte-for-byte corresponding source for the
+historical v1.0.0 binary.
+
+## Recovered high-value symbols
+
+The stable ELF retains symbols for the controller and loader path, including:
+
+```text
+main
+probe_main_entry
+inject_main_entry
+inject_elf
+elfldr_load
+elfldr_payload_args
+Hijacker::getEboot()
+videoout_ioctl::init()
+videoout_ioctl::sample()
+phu_recovery::check_and_reinject()
+```
+
+The exact historical v0.28b contract remains the reconstruction target:
+
+```text
+etaHEN Run / standalone ELF
+        -> fork()
+        -> parent returns immediately
+        -> child performs the full stable initialization
+        -> locate/wait for SceShellUI
+        -> one Trace-Continue loader session
+        -> load embedded renderer
+        -> full elfldr_payload_args()
+        -> renderer Scene readiness
+        -> real read-only VideoOut FPS lifecycle
+```
+
+Do not remove `elfldr_payload_args()`. Historical v0.28a did so and was rejected
+on hardware after a game-launch kernel panic.
+
+## Exact embedded renderer recovered
+
+The stable controller exposes binary-boundary symbols:
+
+```text
+_binary_libphu_overlay_so_start
+_binary_libphu_overlay_so_end
+```
+
+The range is 260,248 bytes and hashes to:
+
+```text
+libphu_overlay.so
+SHA-256 3640cbcaf907bc900e257503b3c8922fdbc129c492a76a2348fd75c84f68b91c
+```
+
+This renderer is a separate ELF shared object embedded in the controller. It is
+not committed to the open-source tree. `tools/analyze_v1_stable.py` can extract
+it locally from a user's verified historical v1.0.0 binary for forensic
+comparison.
+
+Relevant strings and imports show the stable renderer uses the real PS5
+ShellUI/PUI path, including:
+
+```text
+Sce.PlayStation.PUI.dll
+Sce.Vsh.ShellUI.AppSystem.dll
+FindContainerSceneByPath
+Application
+Update
+RootWidget
+FPS:
+FPS: loading
+/system_tmp/phu_hook_ipc
+/user/data/PHU/phu_overlay_online
+```
+
+It also contains its own detour/IPC machinery. This matters because the later
+experimental Stage B/B2/B3 source rewrites attempted a much simpler second
+`Application.Update` hook and were rejected on hardware. The source
+reconstruction must model the stable renderer's coexistence contract rather
+than repeating that design.
+
+## Hardware-rejected paths
+
+The following experimental source branches are explicitly not parity targets:
+
+- Stage B: second ordinary `Application.Update` detour;
+- Stage B2: chaining another Common FPS hook over etaHEN's live hook;
+- Stage B3: stronger visual probe on the same chained-hook architecture.
+
+Observed regressions included no Common FPS overlay, etaHEN GPU/CPU/RAM being
+the only visible overlay, kernel panic on Stop/Run, more frequent YBJB kernel
+panics, and loss of normal CUSA/PPSA display after jailbreak activation.
+
+Therefore the reconstruction rule is:
+
+> Preserve the v1.0.0 loader/renderer contract first. Add autoload readiness
+> only after a source-built manual-run version has hardware parity.
+
+## Reconstruction milestones
+
+1. **Forensic map** — verify the historical binary, recover module/symbol map,
+   and document exact invariants.
+2. **Controller parity** — rebuild the read-only game detection, VideoOut
+   sampler, lifecycle, Trace-Continue loader and full payload-args sequence.
+3. **Renderer parity** — reconstruct the minimal stable ShellUI/PUI renderer
+   behavior and its safe IPC/detour contract.
+4. **Manual hardware parity** — PS4 + PS5, real integer FPS, bottom-left,
+   font 26, purple label/white value, Game A -> Home -> Game B, no KP.
+5. **Autoload-only change** — add a conservative readiness gate before the
+   already-proven stable initialization. Do not redesign the renderer.
+6. **Cross-firmware diagnostics** — only after FW 9.60 parity, investigate the
+   FW 7.60 tester's permanent `FPS: loading` separately from renderer startup.
+
+## Forensic tool
+
+Run against a local copy of the known release; the release binary is not
+required in the repository:
+
+```bash
+python3 tools/analyze_v1_stable.py Common_FPS_PS5_etaHEN_v1.0.0.plugin \
+  --extract-renderer out/libphu_overlay.so \
+  --json out/v1_forensics.json
+```
+
+The tool validates the known wrapper/payload hashes, lists ELF `STT_FILE`
+records, records high-value symbols and verifies the recovered renderer hash.
+It never runs or patches the payload.

--- a/docs/V1_0_0_RECONSTRUCTED_SOURCE_MAP.md
+++ b/docs/V1_0_0_RECONSTRUCTED_SOURCE_MAP.md
@@ -34,23 +34,23 @@ clean-room `CFPS` packet used by the current rewrite.
 - magic: `PHUF` (`0x46554850` on the little-endian target)
 - version: `1`
 
-Recovered layout:
+Exact DWARF-recovered layout:
 
 ```cpp
-struct FpsPacket {
+struct PhuSharedFps {
     uint32_t magic;       // +0x00, PHUF
     uint32_t version;     // +0x04, 1
-    uint64_t sequence;    // +0x08
+    uint64_t seq;         // +0x08
     double   fps;         // +0x10
-    uint64_t reserved;    // +0x18
-    char     raw[1024];   // +0x20
+    uint64_t last_ns;     // +0x18
+    char     text[1024];  // +0x20
 };                       // sizeof = 0x420
 ```
 
-Numeric packets have `raw[0] == 0`. Loading packets use the exact controller
+The public reconstruction uses equivalent names in
+`include/common_fps/v1_stable_wire.hpp` (`sequence` for the recovered `seq`).
+Numeric packets have `text[0] == 0`. Loading packets use the exact controller
 literal `"FPS\tloading\n"` with `fps == 0.0`.
-
-The public source definition is now `include/common_fps/v1_stable_wire.hpp`.
 
 ## 3. Stable FPS sampler
 
@@ -86,13 +86,46 @@ retries.
 The stable renderer formats numeric values with `FPS\t%.0f\n`, so the visible
 FPS is integer-only even though the wire value retains tenth-FPS precision.
 
+### 3.1 Stable game-memory reads are DMAP reads, not per-read ptrace
+
+The historical v1.0.0 outer payload retains `proc_rw_v940.cpp`. Every VideoOut
+table/root/counter read in `probe_main_entry` goes through:
+
+```cpp
+prw::proc_read(pid, virtual_address, output, size)
+```
+
+Recovered `prw::proc_read()` behavior:
+
+1. zero-length read succeeds immediately;
+2. translate the current game virtual address to a physical address and return
+   the mapping page size;
+3. calculate the number of bytes remaining before the current mapping boundary;
+4. copy `min(remaining, bytes_to_boundary)` from
+   `g_dmap_base + physical_address` with `kernel_copyout()`;
+5. advance source/destination and repeat until the whole request is copied;
+6. fail immediately on address-translation or physical-copy failure.
+
+The translator supports the page sizes observed in the donor implementation:
+`4 KiB`, `2 MiB` and `1 GiB`.
+
+This distinction is a parity requirement. The later clean rewrite's
+`pt_attach() -> pt_copyout() -> pt_detach()` for every read is **not** the
+stable v1.0.0 memory path and must not be used by the reconstructed parity
+runtime.
+
+The host-testable page-chunk algorithm is published as
+`v1_stable::proc_read_dmap()` in `include/common_fps/v1_stable_memory.hpp` and
+`src/reconstruction/v1_stable_memory.cpp`. The PS5-specific translator/DMAP
+backend is reconstructed separately from the donor `proc_rw_v940.cpp` behavior.
+
 ## 4. Stable shsrv loader delta
 
 The outer PHU r11 payload and Common FPS v1.0.0 have identical layout and Build
 ID. Only three outer functions contain runtime text changes: `main`,
 `probe_main_entry`, and `elfldr_load`.
 
-The two `elfldr_load` edits are now decoded against pinned shsrv
+The two `elfldr_load` edits are decoded against pinned shsrv
 `6f320637d56d344a0e7797753099e33238bbf146`.
 
 ### 4.1 Continue during local ELF preparation
@@ -179,11 +212,12 @@ calls from the render callback. The remaining donor render/update path is kept.
 ## 6. Reconstruction order
 
 1. exact PHUF wire contract + sampler arithmetic (host-tested);
-2. stable controller lifecycle and process/module probe;
-3. stable shsrv loader delta on top of pinned upstream source;
-4. source reconstruction of the six changed renderer functions on top of the
+2. stable DMAP `proc_read` contract and PS5 translator backend;
+3. stable controller lifecycle and process/module probe;
+4. stable shsrv loader delta on top of pinned upstream source;
+5. source reconstruction of the six changed renderer functions on top of the
    donor architecture and public upstream helpers;
-5. source-built manual-start hardware parity on FW 9.60;
-6. only then add an Autoload readiness gate around the proven initialization.
+6. source-built manual-start hardware parity on FW 9.60;
+7. only then add an Autoload readiness gate around the proven initialization.
 
-No new hardware artifact should be promoted until step 5 passes.
+No new hardware artifact should be promoted until step 6 passes.

--- a/docs/V1_0_0_RECONSTRUCTED_SOURCE_MAP.md
+++ b/docs/V1_0_0_RECONSTRUCTED_SOURCE_MAP.md
@@ -1,0 +1,189 @@
+# v1.0.0 reconstructed runtime source map
+
+This document records facts recovered from the hardware-stable public
+`v1.0.0` binary and the exact PHU Games Tools v1.14.25-r11 donor supplied by
+the project owner.
+
+The goal is source parity first. Autoload changes come only after a source-built
+manual-start candidate reproduces v1.0.0 on hardware.
+
+## 1. Controller entry point
+
+The stable `main` is fully recovered from the binary:
+
+```cpp
+int main() {
+    const pid_t pid = fork();
+    if (pid > 0)
+        return 0;
+    return probe_main_entry();
+}
+```
+
+This is the v0.28b asynchronous activation change. The parent returns to the
+loader immediately and the child keeps the stable initialization/lifecycle.
+
+## 2. Stable controller -> renderer wire contract
+
+The stable controller and stable renderer use UDP loopback, not the later
+clean-room `CFPS` packet used by the current rewrite.
+
+- address: `127.0.0.1`
+- port: `55541`
+- datagram size: `0x420` bytes
+- magic: `PHUF` (`0x46554850` on the little-endian target)
+- version: `1`
+
+Recovered layout:
+
+```cpp
+struct FpsPacket {
+    uint32_t magic;       // +0x00, PHUF
+    uint32_t version;     // +0x04, 1
+    uint64_t sequence;    // +0x08
+    double   fps;         // +0x10
+    uint64_t reserved;    // +0x18
+    char     raw[1024];   // +0x20
+};                       // sizeof = 0x420
+```
+
+Numeric packets have `raw[0] == 0`. Loading packets use the exact controller
+literal `"FPS\tloading\n"` with `fps == 0.0`.
+
+The public source definition is now `include/common_fps/v1_stable_wire.hpp`.
+
+## 3. Stable FPS sampler
+
+`probe_main_entry` calls the unchanged donor `inject_main_entry()` first, then
+creates one UDP socket and runs the game lifecycle.
+
+Target discovery:
+
+- process name: `eboot.bin`
+- module: `libSceVideoOut.sprx`
+- table offset: `0x34980`
+- table entries: `7`
+- entry size: `0x18`
+- first usable entry requires non-zero flag at `+0x00` and pointer at `+0x08`
+- dereference the pointer
+- frame/vsync counter is `dereferenced_base + 0x768`
+- counter width: `uint32_t`
+
+Sampling arithmetic recovered instruction-for-instruction:
+
+```text
+delta_counter = uint32_t(current - previous)
+elapsed_us    = seconds_delta * 1,000,000 + microseconds_delta
+tenths        = delta_counter * 10,000,000 / elapsed_us
+reject if tenths > 3000
+fps           = tenths / 10.0
+```
+
+The controller samples at approximately one-second intervals. If target
+resolution or sampling fails, it sends a loading packet, resets the target, and
+retries.
+
+The stable renderer formats numeric values with `FPS\t%.0f\n`, so the visible
+FPS is integer-only even though the wire value retains tenth-FPS precision.
+
+## 4. Stable shsrv loader delta
+
+The outer PHU r11 payload and Common FPS v1.0.0 have identical layout and Build
+ID. Only three outer functions contain runtime text changes: `main`,
+`probe_main_entry`, and `elfldr_load`.
+
+The two `elfldr_load` edits are now decoded against pinned shsrv
+`6f320637d56d344a0e7797753099e33238bbf146`.
+
+### 4.1 Continue during local ELF preparation
+
+Immediately after the remote `pt_mmap()` reservation succeeds, stable v1.0.0
+preserves the returned mapping address and resumes the traced ShellUI target
+with the equivalent of `PT_CONTINUE`.
+
+The return value from `pt_mmap()` is preserved exactly; failure handling is
+unchanged.
+
+Purpose: the target is not left frozen while the loader performs local ELF
+mapping/copy/relocation preparation.
+
+### 4.2 Re-stop before the next trace-sensitive remote phase
+
+Before the later remote protection/commit phase, stable v1.0.0 synchronously
+stops the same target and waits for the stop to complete, then continues through
+the original shsrv logic.
+
+This is the recovered "Trace Continue" contract: one loader session, temporary
+continue during heavy local preparation, then re-stop before trace-sensitive
+remote operations. It is **not** an intermediate detach/re-attach cycle.
+
+The original `elfldr_payload_args()` phase is retained after the image load.
+Removing payload args was hardware-rejected in the historical v0.28a test.
+
+## 5. Stable renderer delta from PHU r11
+
+The embedded renderer is only 145 runtime bytes different from the exact PHU
+r11 donor (`120` bytes `.text`, `25` bytes `.rodata`). Changed text maps only
+to:
+
+- `elf_main`
+- `read_cfg_v13`
+- `phu_set_fps_text_raw`
+- `phu_create_fps_label`
+- `install_onrender_hook`
+- `OnRender_Hook`
+
+Recovered behavior:
+
+### `elf_main`
+
+- skips PHU-specific pre-Mono startup/diagnostic work that Common FPS does not
+  need;
+- removes the donor's fixed `sleep(3)` completely;
+- retains root-domain/thread attach;
+- retains `mono_glue_init()`;
+- retains the up-to-60-attempt Scene readiness loop with one-second retry;
+- retains the donor's original `install_onrender_hook()` path;
+- binds UDP loopback port `55541`;
+- skips donor runtime-config startup work and enters the PHUF receive loop.
+
+### `read_cfg_v13`
+
+Stable defaults disable unrelated PHU overlays/features and use FPS font size
+`26`. Stable bypasses renderer config-file parsing, making these defaults fixed
+for the release.
+
+### visible FPS
+
+- label text: `FPS:`
+- loading text: `FPS: loading`
+- numeric format: integer (`%.0f`)
+- label color: `#B366FF`
+- value color remains white
+- font size: `26`
+- bottom-left placement uses recovered fixed cursor/anchor values rather than
+  accumulating the cursor each update.
+
+### `install_onrender_hook`
+
+Stable bypasses PHU's optional `patch_main_thread_check()` stage but preserves
+PHU r11's original hook installation path. This distinction is important: the
+hardware-rejected Stage B/B2/B3 experiments attempted to build a second
+independent/chained update hook and are not parity targets.
+
+### `OnRender_Hook`
+
+Stable removes the PHU controller-combo polling and runtime config live-reload
+calls from the render callback. The remaining donor render/update path is kept.
+
+## 6. Reconstruction order
+
+1. exact PHUF wire contract + sampler arithmetic (host-tested);
+2. stable controller lifecycle and process/module probe;
+3. stable shsrv loader delta on top of pinned upstream source;
+4. source reconstruction of the six changed renderer functions on top of the
+   donor architecture and public upstream helpers;
+5. source-built manual-start hardware parity on FW 9.60;
+6. only then add an Autoload readiness gate around the proven initialization.
+
+No new hardware artifact should be promoted until step 5 passes.

--- a/docs/V1_PARITY_PROBE_FW960.md
+++ b/docs/V1_PARITY_PROBE_FW960.md
@@ -1,0 +1,26 @@
+# Stable v1 parity probe — FW 9.60
+
+`Common_FPS_PS5_v1_parity_probe_FW960.elf` is a manual diagnostic payload for the reconstructed hardware-stable v1.0.0 FPS sampler.
+
+It is deliberately separate from the shipping controller/plugin and does not install the ShellUI renderer. The probe uses:
+
+- `V1StableController`
+- `V1StableSampler`
+- `V1StablePs5Platform`
+- PHU-style DMAP translation/read path for FW 9.60
+
+## Hardware test
+
+1. Boot etaHEN normally.
+2. Start a game and wait until gameplay is visible.
+3. Inject `Common_FPS_PS5_v1_parity_probe_FW960.elf` manually.
+4. Do not enable this ELF as an etaHEN autoload plugin.
+5. Wait for one notification.
+
+Expected success notification:
+
+`Common FPS parity probe` followed by `DMAP FW 9.60 OK: <value> FPS`.
+
+The ELF exits after the first numeric FPS sample. If no valid sample is recovered within 90 one-second lifecycle iterations, it emits `No valid FPS after 90 seconds` and exits with status 2.
+
+A successful hardware result validates the reconstructed game-process/module discovery, VideoOut counter resolution, PHU-style page-table translation and physical DMAP reads before any renderer/autoload integration is attempted.

--- a/include/common_fps/phu_compat/hook_ipc.hpp
+++ b/include/common_fps/phu_compat/hook_ipc.hpp
@@ -1,0 +1,60 @@
+/*
+ * Common FPS for PS5
+ *
+ * Compatibility ABI reconstructed from PHU Games Tools v1.14.25-r11.
+ * PHU Games Tools is distributed as mixed GPL/MIT; this project is
+ * GPL-3.0-or-later and preserves PHU provenance for derived compatibility code.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace common_fps::phu_compat {
+
+/* Bytes in memory are "PIUH" on little-endian x86-64. */
+inline constexpr std::uint32_t kHookIpcMagic = 0x48554950u;
+inline constexpr std::size_t kHookIpcMapSize = 0x1000;
+inline constexpr std::size_t kHookIpcDataSize = 512;
+inline constexpr const char* kHookIpcPath = "/system_tmp/phu_hook_ipc";
+
+enum class HookIpcState : std::uint32_t {
+    Idle = 0,
+    Request = 1,
+    Done = 2,
+    Error = 3,
+};
+
+enum class HookIpcOp : std::uint32_t {
+    Read = 1,
+    Write = 2,
+};
+
+/*
+ * Exact 544-byte shared-memory layout recovered from donor DWARF and verified
+ * against DetourFunction machine code.
+ */
+struct HookIpc {
+    volatile std::uint32_t magic;       // +0x00
+    volatile std::uint32_t state;       // +0x04
+    volatile std::uint32_t op;          // +0x08
+    volatile std::uint32_t prot;        // +0x0c
+    volatile std::uint64_t addr;        // +0x10
+    volatile std::uint32_t len;         // +0x18
+    volatile std::int32_t error_code;   // +0x1c
+    volatile std::uint8_t data[kHookIpcDataSize]; // +0x20
+};
+
+static_assert(offsetof(HookIpc, magic) == 0x00);
+static_assert(offsetof(HookIpc, state) == 0x04);
+static_assert(offsetof(HookIpc, op) == 0x08);
+static_assert(offsetof(HookIpc, prot) == 0x0c);
+static_assert(offsetof(HookIpc, addr) == 0x10);
+static_assert(offsetof(HookIpc, len) == 0x18);
+static_assert(offsetof(HookIpc, error_code) == 0x1c);
+static_assert(offsetof(HookIpc, data) == 0x20);
+static_assert(sizeof(HookIpc) == 544);
+
+} // namespace common_fps::phu_compat

--- a/include/common_fps/v1_stable_controller.hpp
+++ b/include/common_fps/v1_stable_controller.hpp
@@ -1,0 +1,43 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#pragma once
+
+#include "common_fps/platform.hpp"
+#include "common_fps/v1_stable_sampler.hpp"
+#include "common_fps/v1_stable_wire.hpp"
+
+#include <cstdint>
+
+namespace common_fps::v1_stable {
+
+class PacketSink {
+public:
+    virtual ~PacketSink() = default;
+    virtual bool send(const FpsPacket& packet) = 0;
+};
+
+/*
+ * Host-testable reconstruction of stable probe_main_entry's game lifecycle.
+ * The PS5 entry point is responsible for installing the stable renderer before
+ * entering this loop; this class only performs game detection/sampling and
+ * PHUF packet publication.
+ */
+class Controller {
+public:
+    Controller(Platform& platform, PacketSink& sink);
+
+    // Perform one stable one-second lifecycle iteration.
+    bool tick();
+
+    std::uint64_t next_sequence() const noexcept { return sequence_; }
+    bool attached() const noexcept { return sampler_.attached(); }
+
+private:
+    bool send_loading();
+
+    Platform& platform_;
+    PacketSink& sink_;
+    Sampler sampler_;
+    std::uint64_t sequence_ = 1;
+};
+
+} // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_detour_model.hpp
+++ b/include/common_fps/v1_stable_detour_model.hpp
@@ -1,0 +1,40 @@
+/*
+ * Common FPS for PS5
+ * Compatibility behavior reconstructed from PHU Games Tools v1.14.25-r11.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace common_fps::v1_stable {
+
+inline constexpr std::size_t kAbsoluteJumpSize = 14;
+inline constexpr std::size_t kDetourProbeBytes = 32;
+
+using JumpBytes = std::array<std::uint8_t, kAbsoluteJumpSize>;
+
+/*
+ * Direct-patch form used when sceKernelMprotect succeeds:
+ *   FF 25 00 00 00 00 <destination: uint64 little-endian>
+ */
+JumpBytes make_ff25_jump(std::uint64_t destination) noexcept;
+
+/*
+ * DMAP fallback form used by the PHU r11 donor:
+ *   49 BB <destination: uint64 little-endian> 41 FF E3 90
+ *   mov r11, imm64 ; jmp r11 ; nop
+ */
+JumpBytes make_r11_jump(std::uint64_t destination) noexcept;
+
+/* Detect the etaHEN/PHU-style 14-byte absolute FF25 jump. */
+bool is_ff25_absolute_jump(const std::uint8_t* bytes,
+                           std::size_t size) noexcept;
+
+/* Decode the destination from a validated FF25 absolute jump. */
+std::uint64_t ff25_destination(const std::uint8_t* bytes,
+                               std::size_t size) noexcept;
+
+} // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_hook_state.hpp
+++ b/include/common_fps/v1_stable_hook_state.hpp
@@ -24,10 +24,9 @@ struct RawSnapshot {
 /*
  * Source reconstruction of the state bridge used by the stable renderer.
  *
- * The donor binary uses an odd/even sequence protocol around fixed 0x400-byte
- * buffers. OnRender reads only a stable even sequence and retries if a writer
- * changed the sequence during the copy. This keeps UI mutation on the render
- * thread while the UDP receiver only publishes text state.
+ * The historical binary uses an odd/even sequence protocol around fixed
+ * 0x400-byte buffers. This source version keeps the same protocol while using
+ * atomic bytes so the behavior is also well-defined under the C++ memory model.
  */
 class HookState {
 public:
@@ -41,14 +40,18 @@ public:
     std::uint64_t raw_sequence() const noexcept;
 
 private:
-    static void copy_text(std::array<char, kHookTextCapacity>& dst,
-                          const char* src);
+    using AtomicBuffer =
+        std::array<std::atomic<unsigned char>, kHookTextCapacity>;
+
+    static void store_text(AtomicBuffer& dst, const char* src);
+    static void load_text(const AtomicBuffer& src,
+                          std::array<char, kHookTextCapacity>& dst);
 
     mutable std::atomic<std::uint64_t> sequence_{0};
     mutable std::atomic<std::uint64_t> raw_sequence_{0};
-    std::array<char, kHookTextCapacity> text_{};
-    std::array<char, kHookTextCapacity> text2_{};
-    std::array<char, kHookTextCapacity> raw_text_{};
+    AtomicBuffer text_{};
+    AtomicBuffer text2_{};
+    AtomicBuffer raw_text_{};
 };
 
 } // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_hook_state.hpp
+++ b/include/common_fps/v1_stable_hook_state.hpp
@@ -1,0 +1,54 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace common_fps::v1_stable {
+
+inline constexpr std::size_t kHookTextCapacity = 1024;
+
+struct TextSnapshot {
+    std::uint64_t sequence = 0;
+    std::array<char, kHookTextCapacity> text{};
+    std::array<char, kHookTextCapacity> text2{};
+};
+
+struct RawSnapshot {
+    std::uint64_t sequence = 0;
+    std::array<char, kHookTextCapacity> text{};
+};
+
+/*
+ * Source reconstruction of the state bridge used by the stable renderer.
+ *
+ * The donor binary uses an odd/even sequence protocol around fixed 0x400-byte
+ * buffers. OnRender reads only a stable even sequence and retries if a writer
+ * changed the sequence during the copy. This keeps UI mutation on the render
+ * thread while the UDP receiver only publishes text state.
+ */
+class HookState {
+public:
+    void publish(const char* text, const char* text2);
+    void publish_raw(const char* text);
+
+    bool snapshot(TextSnapshot& out, unsigned max_attempts = 16) const;
+    bool snapshot_raw(RawSnapshot& out, unsigned max_attempts = 16) const;
+
+    std::uint64_t sequence() const noexcept;
+    std::uint64_t raw_sequence() const noexcept;
+
+private:
+    static void copy_text(std::array<char, kHookTextCapacity>& dst,
+                          const char* src);
+
+    mutable std::atomic<std::uint64_t> sequence_{0};
+    mutable std::atomic<std::uint64_t> raw_sequence_{0};
+    std::array<char, kHookTextCapacity> text_{};
+    std::array<char, kHookTextCapacity> text2_{};
+    std::array<char, kHookTextCapacity> raw_text_{};
+};
+
+} // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_memory.hpp
+++ b/include/common_fps/v1_stable_memory.hpp
@@ -1,0 +1,57 @@
+/*
+ * Common FPS for PS5
+ * Stable v1.0.0 memory-read behavior reconstructed from PHU r11.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include "common_fps/platform.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace common_fps::v1_stable {
+
+struct PageTranslation {
+    std::uintptr_t physical = 0;
+    std::size_t page_size = 0;
+};
+
+/*
+ * Host-testable boundary around the historical PHU DMAP reader.
+ *
+ * The real PS5 implementation of stable v1.0.0 used:
+ *   translate(pid, virtual_address, &page_size)
+ *   kernel_copyout(g_dmap_base + physical_address, ...)
+ *
+ * It did NOT pt_attach()/pt_detach() the game for every VideoOut read.
+ */
+class DmapReadBackend {
+public:
+    virtual ~DmapReadBackend() = default;
+
+    virtual std::optional<PageTranslation>
+    translate(ProcessId pid, std::uintptr_t virtual_address) = 0;
+
+    virtual bool copy_physical(
+        std::uintptr_t physical_address,
+        void* output,
+        std::size_t size) = 0;
+};
+
+/*
+ * Reconstructed prw::proc_read() chunking semantics.
+ *
+ * A read may cross 4 KiB / 2 MiB / 1 GiB mappings. The historical routine
+ * translates each current virtual address, limits the copy to the remaining
+ * bytes in that mapping, then repeats until the requested length is complete.
+ */
+bool proc_read_dmap(
+    DmapReadBackend& backend,
+    ProcessId pid,
+    std::uintptr_t virtual_address,
+    void* output,
+    std::size_t size) noexcept;
+
+} // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_memory.hpp
+++ b/include/common_fps/v1_stable_memory.hpp
@@ -18,6 +18,24 @@ struct PageTranslation {
     std::size_t page_size = 0;
 };
 
+/* Read one 64-bit x86-64 page-table entry by physical address. */
+class PhysicalEntryReader {
+public:
+    virtual ~PhysicalEntryReader() = default;
+    virtual bool read_entry(
+        std::uintptr_t physical_address,
+        std::uint64_t& value) = 0;
+};
+
+/*
+ * Four-level x86-64 page-table translation used by the PHU DMAP reader.
+ * Supports ordinary 4 KiB mappings plus PS-bit 2 MiB and 1 GiB mappings.
+ */
+std::optional<PageTranslation> translate_x86_64(
+    PhysicalEntryReader& reader,
+    std::uintptr_t cr3_physical,
+    std::uintptr_t virtual_address) noexcept;
+
 /*
  * Host-testable boundary around the historical PHU DMAP reader.
  *

--- a/include/common_fps/v1_stable_overlay.hpp
+++ b/include/common_fps/v1_stable_overlay.hpp
@@ -1,0 +1,38 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#pragma once
+
+#include <cstdint>
+
+namespace common_fps::v1_stable {
+
+inline constexpr const char* kLabelText = "FPS:";
+inline constexpr const char* kNumericFormat = "%.0f";
+inline constexpr const char* kLoadingVisibleText = "FPS: loading";
+
+inline constexpr int kFontSize = 26;
+
+// Stable v1.0.0 raw-text parser resets these before laying out each update.
+inline constexpr float kRawCursorX = 10.0f;
+inline constexpr float kRawCursorY = 1038.0f;
+
+struct Rgba8 {
+    std::uint8_t r;
+    std::uint8_t g;
+    std::uint8_t b;
+    std::uint8_t a;
+};
+
+inline constexpr Rgba8 kLabelColor{0xB3, 0x66, 0xFF, 0xFF};
+inline constexpr Rgba8 kValueColor{0xFF, 0xFF, 0xFF, 0xFF};
+
+// Recovered from the stable phu_create_fps_label path. With a 1920-wide
+// logical root this evaluates to 1070.0 before the label-specific layout work.
+inline constexpr float kInitialCursorX = 4.0f;
+inline constexpr float kInitialCursorScale = 0.5625f;
+inline constexpr float kInitialCursorMargin = 10.0f;
+
+constexpr float initial_cursor_y(float root_width) noexcept {
+    return root_width * kInitialCursorScale - kInitialCursorMargin;
+}
+
+} // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_render_loop.hpp
+++ b/include/common_fps/v1_stable_render_loop.hpp
@@ -1,0 +1,46 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#pragma once
+
+#include "common_fps/v1_stable_hook_state.hpp"
+
+#include <cstdint>
+
+namespace common_fps::v1_stable {
+
+class RenderActions {
+public:
+    virtual ~RenderActions() = default;
+
+    virtual bool create_fps_label() = 0;
+    virtual void set_fps_text_raw(const char* text) = 0;
+    virtual void set_fps_text(const char* text, const char* text2) = 0;
+};
+
+/*
+ * UI-independent reconstruction of the stable v1.0.0 OnRender_Hook body.
+ *
+ * The actual ShellUI adapter will call this only from the existing PUI update
+ * callback, then invoke the original callback. Keeping the state machine here
+ * makes the behavior host-testable without loading or mutating PS5 UI state.
+ */
+class RenderLoop {
+public:
+    void update(const HookState& state, RenderActions& actions);
+
+    std::uint32_t tick() const noexcept { return tick_; }
+    bool label_ready() const noexcept { return label_ready_; }
+    std::uint64_t last_sequence() const noexcept { return last_sequence_; }
+    std::uint64_t last_raw_sequence() const noexcept {
+        return last_raw_sequence_;
+    }
+
+private:
+    static constexpr std::uint32_t kLabelDelayTicks = 30;
+
+    std::uint32_t tick_ = 0;
+    bool label_ready_ = false;
+    std::uint64_t last_sequence_ = 0;
+    std::uint64_t last_raw_sequence_ = 0;
+};
+
+} // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_sampler.hpp
+++ b/include/common_fps/v1_stable_sampler.hpp
@@ -1,0 +1,35 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#pragma once
+
+#include "common_fps/platform.hpp"
+
+#include <cstdint>
+#include <optional>
+
+namespace common_fps::v1_stable {
+
+class Sampler {
+public:
+    explicit Sampler(Platform& platform);
+
+    bool attach(ProcessId pid);
+    std::optional<double> sample();
+    void reset();
+
+    bool attached() const noexcept;
+    ProcessId pid() const noexcept;
+    std::uintptr_t counter_address() const noexcept;
+
+private:
+    bool resolve_counter_address();
+
+    Platform& platform_;
+    ProcessId pid_ = -1;
+    std::uintptr_t module_base_ = 0;
+    std::uintptr_t counter_address_ = 0;
+    bool have_baseline_ = false;
+    std::uint32_t previous_counter_ = 0;
+    std::uint64_t previous_time_us_ = 0;
+};
+
+} // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_wire.hpp
+++ b/include/common_fps/v1_stable_wire.hpp
@@ -1,0 +1,70 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+
+namespace common_fps::v1_stable {
+
+inline constexpr std::uint32_t kWireMagic = 0x46554850u; // PHUF
+inline constexpr std::uint32_t kWireVersion = 1;
+inline constexpr std::uint16_t kWirePort = 55541;
+inline constexpr std::size_t kRawTextCapacity = 1024;
+inline constexpr std::uint32_t kMaxTenthsFps = 3000;
+
+struct FpsPacket {
+    std::uint32_t magic = kWireMagic;
+    std::uint32_t version = kWireVersion;
+    std::uint64_t sequence = 0;
+    double fps = 0.0;
+    std::uint64_t reserved = 0;
+    char raw[kRawTextCapacity]{};
+};
+
+static_assert(offsetof(FpsPacket, magic) == 0x00);
+static_assert(offsetof(FpsPacket, version) == 0x04);
+static_assert(offsetof(FpsPacket, sequence) == 0x08);
+static_assert(offsetof(FpsPacket, fps) == 0x10);
+static_assert(offsetof(FpsPacket, reserved) == 0x18);
+static_assert(offsetof(FpsPacket, raw) == 0x20);
+static_assert(sizeof(FpsPacket) == 0x420);
+
+inline void set_loading(FpsPacket& packet, std::uint64_t sequence) {
+    packet = {};
+    packet.magic = kWireMagic;
+    packet.version = kWireVersion;
+    packet.sequence = sequence;
+    constexpr char kLoading[] = "FPS\tloading\n";
+    std::memcpy(packet.raw, kLoading, sizeof(kLoading));
+}
+
+inline void set_numeric(FpsPacket& packet,
+                        std::uint64_t sequence,
+                        double fps) {
+    packet = {};
+    packet.magic = kWireMagic;
+    packet.version = kWireVersion;
+    packet.sequence = sequence;
+    packet.fps = fps;
+    packet.raw[0] = '\0';
+}
+
+inline std::optional<double> calculate_fps(std::uint32_t previous_counter,
+                                           std::uint32_t current_counter,
+                                           std::uint64_t elapsed_us) {
+    if (elapsed_us == 0)
+        return std::nullopt;
+
+    const std::uint32_t delta = current_counter - previous_counter;
+    const std::uint64_t tenths =
+        (static_cast<std::uint64_t>(delta) * 10000000ull) / elapsed_us;
+
+    if (tenths > kMaxTenthsFps)
+        return std::nullopt;
+
+    return static_cast<double>(tenths) / 10.0;
+}
+
+} // namespace common_fps::v1_stable

--- a/include/common_fps/v1_stable_wire.hpp
+++ b/include/common_fps/v1_stable_wire.hpp
@@ -11,24 +11,28 @@ namespace common_fps::v1_stable {
 inline constexpr std::uint32_t kWireMagic = 0x46554850u; // PHUF
 inline constexpr std::uint32_t kWireVersion = 1;
 inline constexpr std::uint16_t kWirePort = 55541;
-inline constexpr std::size_t kRawTextCapacity = 1024;
+inline constexpr std::size_t kTextCapacity = 1024;
 inline constexpr std::uint32_t kMaxTenthsFps = 3000;
 
+/*
+ * Exact field names/layout recovered from PHU r11 DWARF and verified against
+ * the hardware-stable Common FPS v1.0.0 sender/receiver disassembly.
+ */
 struct FpsPacket {
     std::uint32_t magic = kWireMagic;
     std::uint32_t version = kWireVersion;
     std::uint64_t sequence = 0;
     double fps = 0.0;
-    std::uint64_t reserved = 0;
-    char raw[kRawTextCapacity]{};
+    std::uint64_t last_ns = 0;
+    char text[kTextCapacity]{};
 };
 
 static_assert(offsetof(FpsPacket, magic) == 0x00);
 static_assert(offsetof(FpsPacket, version) == 0x04);
 static_assert(offsetof(FpsPacket, sequence) == 0x08);
 static_assert(offsetof(FpsPacket, fps) == 0x10);
-static_assert(offsetof(FpsPacket, reserved) == 0x18);
-static_assert(offsetof(FpsPacket, raw) == 0x20);
+static_assert(offsetof(FpsPacket, last_ns) == 0x18);
+static_assert(offsetof(FpsPacket, text) == 0x20);
 static_assert(sizeof(FpsPacket) == 0x420);
 
 inline void set_loading(FpsPacket& packet, std::uint64_t sequence) {
@@ -37,7 +41,7 @@ inline void set_loading(FpsPacket& packet, std::uint64_t sequence) {
     packet.version = kWireVersion;
     packet.sequence = sequence;
     constexpr char kLoading[] = "FPS\tloading\n";
-    std::memcpy(packet.raw, kLoading, sizeof(kLoading));
+    std::memcpy(packet.text, kLoading, sizeof(kLoading));
 }
 
 inline void set_numeric(FpsPacket& packet,
@@ -48,7 +52,7 @@ inline void set_numeric(FpsPacket& packet,
     packet.version = kWireVersion;
     packet.sequence = sequence;
     packet.fps = fps;
-    packet.raw[0] = '\0';
+    packet.text[0] = '\0';
 }
 
 inline std::optional<double> calculate_fps(std::uint32_t previous_counter,

--- a/integration/loader/v1_loader_contract.cpp
+++ b/integration/loader/v1_loader_contract.cpp
@@ -20,18 +20,19 @@ bool install_renderer_v1_compatible(
     if (!b.begin_loader_session())
         return false;
 
+    const auto image = b.load_renderer_image(elf, size);
+    if (!image || image->entry == 0) {
+        b.end_loader_session();
+        return false;
+    }
+
     const auto args = b.prepare_payload_args();
     if (!args) {
         b.end_loader_session();
         return false;
     }
 
-    if (!b.load_renderer(elf, size, args)) {
-        b.end_loader_session();
-        return false;
-    }
-
-    if (!b.continue_target()) {
+    if (!b.prepare_exec(image->entry, args)) {
         b.end_loader_session();
         return false;
     }

--- a/integration/loader/v1_loader_contract.hpp
+++ b/integration/loader/v1_loader_contract.hpp
@@ -3,30 +3,53 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 #pragma once
+
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 namespace common_fps::loader {
+
+struct LoadedImage {
+    std::uintptr_t entry = 0;
+    std::uintptr_t base = 0;
+};
 
 class Backend {
 public:
     virtual ~Backend() = default;
 
-    // v0.27a: required or overlay may never appear.
+    // Historical v0.27a: do not start the loader before ShellUI Scene exists.
     virtual bool wait_for_shellui_scene() = 0;
 
-    // v0.27b/c: one continuous loader session.
+    // Historical v0.27b/c: one continuous trace/loader session.
     virtual bool begin_loader_session() = 0;
 
-    // v0.28a: must not be removed.
+    /*
+     * Load the renderer image first.
+     *
+     * The PS5 backend for this operation must implement the recovered v1.0.0
+     * shsrv Trace Continue behavior inside image loading:
+     *   reserve remote image -> temporarily continue target while doing local
+     *   ELF preparation -> synchronously re-stop before later remote/protection
+     *   operations. No intermediate detach/re-attach is allowed.
+     */
+    virtual std::optional<LoadedImage> load_renderer_image(
+        const std::uint8_t* elf,
+        std::size_t size) = 0;
+
+    // Historical v0.28a hardware result: this phase must be retained.
     virtual std::uintptr_t prepare_payload_args() = 0;
 
-    virtual bool load_renderer(
-        const std::uint8_t* elf,
-        std::size_t size,
+    // Equivalent to shsrv's register preparation after image + payload args.
+    virtual bool prepare_exec(
+        std::uintptr_t entry,
         std::uintptr_t payload_args) = 0;
 
-    virtual bool continue_target() = 0;
+    /*
+     * Finish the same loader session. On the real backend this is the final
+     * detach/resume path; there is no second independent continue step here.
+     */
     virtual bool end_loader_session() = 0;
 };
 

--- a/ps5/CMakeLists.txt
+++ b/ps5/CMakeLists.txt
@@ -146,6 +146,37 @@ target_link_libraries(common_fps_shellui PRIVATE
 )
 
 # ------------------------------------------------------------------
+# Stable-v1 reconstruction compile check.
+#
+# This archive is deliberately NOT linked into the shipping controller yet.
+# Its purpose is to compile the reconstructed PHU-style DMAP read path with
+# the real PS5 toolchain while manual-run parity work is still in progress.
+# Building it cannot change the runtime ELF/plugin behavior.
+# ------------------------------------------------------------------
+add_library(common_fps_v1_ps5_reconstruction STATIC
+    "${ROOT}/src/reconstruction/v1_stable_memory.cpp"
+    "${ROOT}/src/ps5/v1_stable_dmap_backend.cpp"
+    "${ROOT}/src/ps5/v1_stable_ps5_platform.cpp"
+)
+
+target_include_directories(common_fps_v1_ps5_reconstruction PRIVATE
+    "${ROOT}/include"
+    "${ROOT}/src/ps5"
+    "${SDK}"
+    "${SDK}/include"
+)
+
+target_compile_options(common_fps_v1_ps5_reconstruction PRIVATE
+    --target=x86_64-sie-ps5
+    -DPS5
+    -fPIC
+    -march=znver2
+    -O2
+    -Wall
+    -Wextra
+)
+
+# ------------------------------------------------------------------
 # Package controller as etaHEN .plugin.
 # The renderer ELF remains a source-built companion artifact until the
 # controller-side loader embedding step is validated.

--- a/ps5/CMakeLists.txt
+++ b/ps5/CMakeLists.txt
@@ -192,7 +192,11 @@ add_executable(common_fps_v1_parity_probe
     "${ROOT}/src/ps5/ps5_platform.cpp"
     "${ROOT}/src/ps5/v1_parity_probe_main.cpp"
 
+    # Match etaHEN fps_elf's cross-process access setup: enumerate kernel proc
+    # state and temporarily switch this probe to DEBUG_AUTHID before dynlib
+    # queries against the game process.
     "${ETAHEN_FPS}/src/proc.cpp"
+    "${ETAHEN_FPS}/src/ucred.cpp"
     "${COMMON_FPS_SHSRV_SOURCE}/pt.c"
 )
 

--- a/ps5/CMakeLists.txt
+++ b/ps5/CMakeLists.txt
@@ -162,6 +162,8 @@ add_library(common_fps_v1_ps5_reconstruction STATIC
 target_include_directories(common_fps_v1_ps5_reconstruction PRIVATE
     "${ROOT}/include"
     "${ROOT}/src/ps5"
+    "${ETAHEN_ROOT}/include"
+    "${ETAHEN_FPS}/include"
     "${SDK}"
     "${SDK}/include"
 )

--- a/ps5/CMakeLists.txt
+++ b/ps5/CMakeLists.txt
@@ -177,6 +177,69 @@ target_compile_options(common_fps_v1_ps5_reconstruction PRIVATE
 )
 
 # ------------------------------------------------------------------
+# FW 9.60 stable-v1 manual parity probe.
+#
+# Separate diagnostic ELF only. It exercises the reconstructed stable
+# Controller + Sampler + PHU-style DMAP backend and exits after the first
+# numeric FPS sample. It does not install ShellUI hooks and cannot replace the
+# shipping Common_FPS_PS5_v1.1.0.elf/plugin by accident.
+# ------------------------------------------------------------------
+add_executable(common_fps_v1_parity_probe
+    "${ROOT}/src/reconstruction/v1_stable_sampler.cpp"
+    "${ROOT}/src/reconstruction/v1_stable_controller.cpp"
+    "${ROOT}/src/ps5/ps5_platform.cpp"
+    "${ROOT}/src/ps5/v1_parity_probe_main.cpp"
+
+    "${ETAHEN_FPS}/src/proc.cpp"
+    "${COMMON_FPS_SHSRV_SOURCE}/pt.c"
+)
+
+set_target_properties(common_fps_v1_parity_probe PROPERTIES
+    OUTPUT_NAME "Common_FPS_PS5_v1_parity_probe_FW960.elf"
+)
+
+target_include_directories(common_fps_v1_parity_probe PRIVATE
+    "${ROOT}/include"
+    "${ROOT}/src/ps5"
+    "${ETAHEN_ROOT}/include"
+    "${ETAHEN_FPS}/include"
+    "${COMMON_FPS_SHSRV_SOURCE}"
+    "${SDK}"
+    "${SDK}/include"
+)
+
+target_compile_options(common_fps_v1_parity_probe PRIVATE
+    --target=x86_64-sie-ps5
+    -DPS5
+    -fPIC
+    -fPIE
+    -march=znver2
+    -O2
+    -Wall
+    -Wextra
+)
+
+target_link_libraries(common_fps_v1_parity_probe PRIVATE
+    common_fps_v1_ps5_reconstruction
+    kernel_sys
+    SceLibcInternal
+    SceSystemService
+    SceNet
+    SceSysmodule
+    SceUserService
+    SceNetCtl
+)
+
+add_custom_command(
+    TARGET common_fps_v1_parity_probe
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${ROOT}/dist"
+    COMMAND ${CMAKE_COMMAND} -E copy
+            "$<TARGET_FILE:common_fps_v1_parity_probe>"
+            "${ROOT}/dist/Common_FPS_PS5_v1_parity_probe_FW960.elf"
+)
+
+# ------------------------------------------------------------------
 # Package controller as etaHEN .plugin.
 # The renderer ELF remains a source-built companion artifact until the
 # controller-side loader embedding step is validated.

--- a/scripts/ps5_source_build.sh
+++ b/scripts/ps5_source_build.sh
@@ -25,11 +25,13 @@ mkdir -p "${ROOT}/dist"
 test -f "${ROOT}/dist/Common_FPS_PS5_v1.1.0.elf"
 test -f "${ROOT}/dist/Common_FPS_PS5_etaHEN_v1.1.0.plugin"
 test -f "${ROOT}/dist/Common_FPS_ShellUI_v1.1.0.elf"
+test -f "${ROOT}/dist/Common_FPS_PS5_v1_parity_probe_FW960.elf"
 
 sha256sum \
   "${ROOT}/dist/Common_FPS_PS5_v1.1.0.elf" \
   "${ROOT}/dist/Common_FPS_PS5_etaHEN_v1.1.0.plugin" \
   "${ROOT}/dist/Common_FPS_ShellUI_v1.1.0.elf" \
+  "${ROOT}/dist/Common_FPS_PS5_v1_parity_probe_FW960.elf" \
   > "${ROOT}/dist/SHA256SUMS.txt"
 
 cat "${ROOT}/dist/SHA256SUMS.txt"

--- a/src/ps5/v1_parity_probe_main.cpp
+++ b/src/ps5/v1_parity_probe_main.cpp
@@ -4,10 +4,9 @@
  *
  * This diagnostic ELF intentionally does not install the ShellUI renderer and
  * does not replace the shipping controller/plugin. It writes every completed
- * stage to /data/CommonFPS_v1_probe.log and flushes immediately, so a silent
- * notification path cannot hide where FW 9.60 parity stops.
+ * stage to /data/CommonFPS_v1_probe.log and flushes immediately.
  *
- * v3 restored the stable line's sysctl/find_pid game discovery.
+ * v3 restored sysctl/find_pid game discovery.
  * v4 restores target dynlib module enumeration with basename/suffix matching
  * and records the raw FW 9.60 module list around the VideoOut lookup.
  *
@@ -16,6 +15,7 @@
 
 #include "common_fps/constants.hpp"
 #include "common_fps/v1_stable_sampler.hpp"
+#include "v1_stable_dynlib.hpp"
 #include "v1_stable_ps5_platform.hpp"
 
 #include <algorithm>
@@ -30,8 +30,6 @@
 #include <vector>
 
 extern "C" {
-#include "proc.h"
-
 typedef struct notify_request {
     char padding[45];
     char message[3075];
@@ -47,13 +45,11 @@ int sceKernelSendNotificationRequest(
 namespace {
 
 constexpr const char* kLogPath = "/data/CommonFPS_v1_probe.log";
-
 FILE* g_log = nullptr;
 
 void log_line(const char* fmt, ...) {
     if (!g_log)
         return;
-
     va_list args;
     va_start(args, fmt);
     std::vfprintf(g_log, fmt, args);
@@ -65,50 +61,38 @@ void log_line(const char* fmt, ...) {
 void notify(const char* message) {
     notify_request_t request{};
     std::snprintf(request.message, sizeof(request.message), "%s", message);
-    const int rc = sceKernelSendNotificationRequest(
-        0, &request, sizeof(request), 0);
+    const int rc = sceKernelSendNotificationRequest(0, &request, sizeof(request), 0);
     log_line("NOTIFY rc=%d text=%s", rc, message);
 }
 
 void log_dynlib_scan(common_fps::ProcessId pid) {
+    using namespace common_fps::ps5;
+
     std::size_t handle_count = 0;
-    const long count_rc = syscall(
-        SYS_dl_get_list, pid, nullptr, 0, &handle_count);
+    const long count_rc = syscall(kSysDlGetList, pid, nullptr, 0, &handle_count);
     log_line(
         "S2RAW get_list(count) rc=%ld count=%llu",
         count_rc,
         static_cast<unsigned long long>(handle_count));
-
     if (count_rc < 0 || handle_count == 0)
         return;
 
     std::vector<std::uintptr_t> handles(handle_count);
     std::size_t returned_count = handle_count;
     const long list_rc = syscall(
-        SYS_dl_get_list,
-        pid,
-        handles.data(),
-        handles.size(),
-        &returned_count);
+        kSysDlGetList, pid, handles.data(), handles.size(), &returned_count);
     log_line(
         "S2RAW get_list(fill) rc=%ld returned=%llu capacity=%llu",
         list_rc,
         static_cast<unsigned long long>(returned_count),
         static_cast<unsigned long long>(handles.size()));
-
     if (list_rc < 0)
         return;
 
     returned_count = std::min(returned_count, handles.size());
     for (std::size_t i = 0; i < returned_count; ++i) {
-        module_info_t info{};
-        const long info_rc = syscall(
-            SYS_dl_get_info_2,
-            pid,
-            1,
-            handles[i],
-            &info);
-
+        DynlibModuleInfo info{};
+        const long info_rc = syscall(kSysDlGetInfo2, pid, 1, handles[i], &info);
         if (info_rc < 0) {
             if (i < 8) {
                 log_line(
@@ -148,7 +132,6 @@ int main() {
     notify("Common FPS parity probe v4\nSTART");
 
     common_fps::ps5::V1StablePs5Platform platform;
-
     std::optional<common_fps::ProcessId> pid;
     for (unsigned attempt = 0; attempt < 30; ++attempt) {
         pid = platform.find_game_process();
@@ -162,8 +145,7 @@ int main() {
     if (!pid) {
         log_line("FAIL S1 sysctl game process not found after 30s");
         notify("Common FPS parity probe v4\nFAIL S1: game not found");
-        if (g_log)
-            std::fclose(g_log);
+        if (g_log) std::fclose(g_log);
         return 11;
     }
     log_line("S1 game pid=%d", *pid);
@@ -174,8 +156,7 @@ int main() {
     if (!module || module->base == 0) {
         log_line("FAIL S2 libSceVideoOut.sprx not found");
         notify("Common FPS parity probe v4\nFAIL S2: VideoOut module");
-        if (g_log)
-            std::fclose(g_log);
+        if (g_log) std::fclose(g_log);
         return 12;
     }
     log_line(
@@ -184,12 +165,10 @@ int main() {
         static_cast<unsigned long long>(module->base));
 
     constexpr std::size_t kTableSize =
-        common_fps::kVideoOutProbeEntryCount *
-        common_fps::kVideoOutProbeEntrySize;
+        common_fps::kVideoOutProbeEntryCount * common_fps::kVideoOutProbeEntrySize;
     std::array<std::uint8_t, kTableSize> table{};
 
-    const auto table_address =
-        module->base + common_fps::kVideoOutProbeTableOffset;
+    const auto table_address = module->base + common_fps::kVideoOutProbeTableOffset;
     const bool table_ok = platform.read_memory(
         *pid, table_address, table.data(), table.size());
 
@@ -204,8 +183,7 @@ int main() {
 
     if (!table_ok) {
         notify("Common FPS parity probe v4\nFAIL S3: DMAP table read");
-        if (g_log)
-            std::fclose(g_log);
+        if (g_log) std::fclose(g_log);
         return 13;
     }
 
@@ -216,8 +194,7 @@ int main() {
             dmap.last_sdk_version(),
             static_cast<unsigned long long>(dmap.last_dmap_base()));
         notify("Common FPS parity probe v4\nFAIL S4: sampler attach");
-        if (g_log)
-            std::fclose(g_log);
+        if (g_log) std::fclose(g_log);
         return 14;
     }
 
@@ -237,8 +214,7 @@ int main() {
                 *fps);
             notify(message);
             platform.sleep_ms(1500);
-            if (g_log)
-                std::fclose(g_log);
+            if (g_log) std::fclose(g_log);
             return 0;
         }
 
@@ -246,7 +222,6 @@ int main() {
             "S5 sample %u no-value attached=%s",
             attempt + 1,
             sampler.attached() ? "yes" : "no");
-
         if (!sampler.attached())
             break;
         platform.sleep_ms(1000);
@@ -254,7 +229,6 @@ int main() {
 
     log_line("FAIL S5 no valid FPS");
     notify("Common FPS parity probe v4\nFAIL S5: no valid FPS");
-    if (g_log)
-        std::fclose(g_log);
+    if (g_log) std::fclose(g_log);
     return 15;
 }

--- a/src/ps5/v1_parity_probe_main.cpp
+++ b/src/ps5/v1_parity_probe_main.cpp
@@ -1,14 +1,15 @@
 /*
  * Common FPS for PS5
- * Hardware parity probe v3 for the reconstructed stable v1.0.0 FPS sampler.
+ * Hardware parity probe v4 for the reconstructed stable v1.0.0 FPS sampler.
  *
  * This diagnostic ELF intentionally does not install the ShellUI renderer and
  * does not replace the shipping controller/plugin. It writes every completed
  * stage to /data/CommonFPS_v1_probe.log and flushes immediately, so a silent
  * notification path cannot hide where FW 9.60 parity stops.
  *
- * v3 restores the stable line's sysctl/find_pid game discovery instead of the
- * later clean rewrite's etaHEN allproc helper.
+ * v3 restored the stable line's sysctl/find_pid game discovery.
+ * v4 restores target dynlib module enumeration with basename/suffix matching
+ * and records the raw FW 9.60 module list around the VideoOut lookup.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
@@ -17,14 +18,19 @@
 #include "common_fps/v1_stable_sampler.hpp"
 #include "v1_stable_ps5_platform.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
 
 extern "C" {
+#include "proc.h"
 
 typedef struct notify_request {
     char padding[45];
@@ -64,16 +70,82 @@ void notify(const char* message) {
     log_line("NOTIFY rc=%d text=%s", rc, message);
 }
 
+void log_dynlib_scan(common_fps::ProcessId pid) {
+    std::size_t handle_count = 0;
+    const long count_rc = syscall(
+        SYS_dl_get_list, pid, nullptr, 0, &handle_count);
+    log_line(
+        "S2RAW get_list(count) rc=%ld count=%llu",
+        count_rc,
+        static_cast<unsigned long long>(handle_count));
+
+    if (count_rc < 0 || handle_count == 0)
+        return;
+
+    std::vector<std::uintptr_t> handles(handle_count);
+    std::size_t returned_count = handle_count;
+    const long list_rc = syscall(
+        SYS_dl_get_list,
+        pid,
+        handles.data(),
+        handles.size(),
+        &returned_count);
+    log_line(
+        "S2RAW get_list(fill) rc=%ld returned=%llu capacity=%llu",
+        list_rc,
+        static_cast<unsigned long long>(returned_count),
+        static_cast<unsigned long long>(handles.size()));
+
+    if (list_rc < 0)
+        return;
+
+    returned_count = std::min(returned_count, handles.size());
+    for (std::size_t i = 0; i < returned_count; ++i) {
+        module_info_t info{};
+        const long info_rc = syscall(
+            SYS_dl_get_info_2,
+            pid,
+            1,
+            handles[i],
+            &info);
+
+        if (info_rc < 0) {
+            if (i < 8) {
+                log_line(
+                    "S2RAW[%llu] info rc=%ld handle=0x%llx",
+                    static_cast<unsigned long long>(i),
+                    info_rc,
+                    static_cast<unsigned long long>(handles[i]));
+            }
+            continue;
+        }
+
+        const bool interesting =
+            i < 12 ||
+            std::strstr(info.filename, "Video") != nullptr ||
+            std::strstr(info.filename, "video") != nullptr;
+        if (!interesting)
+            continue;
+
+        log_line(
+            "S2RAW[%llu] name=%s base=0x%llx handle=0x%llx",
+            static_cast<unsigned long long>(i),
+            info.filename,
+            static_cast<unsigned long long>(info.sections[0].vaddr),
+            static_cast<unsigned long long>(handles[i]));
+    }
+}
+
 } // namespace
 
 int main() {
     g_log = std::fopen(kLogPath, "w");
     if (g_log) {
         std::setvbuf(g_log, nullptr, _IONBF, 0);
-        log_line("S0 main entered v3");
+        log_line("S0 main entered v4");
     }
 
-    notify("Common FPS parity probe v3\nSTART");
+    notify("Common FPS parity probe v4\nSTART");
 
     common_fps::ps5::V1StablePs5Platform platform;
 
@@ -89,23 +161,26 @@ int main() {
 
     if (!pid) {
         log_line("FAIL S1 sysctl game process not found after 30s");
-        notify("Common FPS parity probe v3\nFAIL S1: game not found");
+        notify("Common FPS parity probe v4\nFAIL S1: game not found");
         if (g_log)
             std::fclose(g_log);
         return 11;
     }
     log_line("S1 game pid=%d", *pid);
 
+    log_dynlib_scan(*pid);
+
     const auto module = platform.find_module(*pid, "libSceVideoOut.sprx");
     if (!module || module->base == 0) {
         log_line("FAIL S2 libSceVideoOut.sprx not found");
-        notify("Common FPS parity probe v3\nFAIL S2: VideoOut module");
+        notify("Common FPS parity probe v4\nFAIL S2: VideoOut module");
         if (g_log)
             std::fclose(g_log);
         return 12;
     }
     log_line(
-        "S2 VideoOut base=0x%llx",
+        "S2 VideoOut name=%s base=0x%llx",
+        module->name.c_str(),
         static_cast<unsigned long long>(module->base));
 
     constexpr std::size_t kTableSize =
@@ -128,7 +203,7 @@ int main() {
         static_cast<unsigned long long>(table.size()));
 
     if (!table_ok) {
-        notify("Common FPS parity probe v3\nFAIL S3: DMAP table read");
+        notify("Common FPS parity probe v4\nFAIL S3: DMAP table read");
         if (g_log)
             std::fclose(g_log);
         return 13;
@@ -140,7 +215,7 @@ int main() {
             "FAIL S4 sampler attach sdk=0x%08x dmap=0x%llx",
             dmap.last_sdk_version(),
             static_cast<unsigned long long>(dmap.last_dmap_base()));
-        notify("Common FPS parity probe v3\nFAIL S4: sampler attach");
+        notify("Common FPS parity probe v4\nFAIL S4: sampler attach");
         if (g_log)
             std::fclose(g_log);
         return 14;
@@ -158,7 +233,7 @@ int main() {
             std::snprintf(
                 message,
                 sizeof(message),
-                "Common FPS parity probe v3\nDMAP FW 9.60 OK: %.1f FPS",
+                "Common FPS parity probe v4\nDMAP FW 9.60 OK: %.1f FPS",
                 *fps);
             notify(message);
             platform.sleep_ms(1500);
@@ -178,7 +253,7 @@ int main() {
     }
 
     log_line("FAIL S5 no valid FPS");
-    notify("Common FPS parity probe v3\nFAIL S5: no valid FPS");
+    notify("Common FPS parity probe v4\nFAIL S5: no valid FPS");
     if (g_log)
         std::fclose(g_log);
     return 15;

--- a/src/ps5/v1_parity_probe_main.cpp
+++ b/src/ps5/v1_parity_probe_main.cpp
@@ -1,14 +1,16 @@
 /*
  * Common FPS for PS5
- * Hardware parity probe v4 for the reconstructed stable v1.0.0 FPS sampler.
+ * Hardware parity probe v5 for the reconstructed stable v1.0.0 FPS sampler.
  *
  * This diagnostic ELF intentionally does not install the ShellUI renderer and
  * does not replace the shipping controller/plugin. It writes every completed
  * stage to /data/CommonFPS_v1_probe.log and flushes immediately.
  *
  * v3 restored sysctl/find_pid game discovery.
- * v4 restores target dynlib module enumeration with basename/suffix matching
- * and records the raw FW 9.60 module list around the VideoOut lookup.
+ * v4 restored target dynlib enumeration and proved that the game process is
+ *    found but cross-process SYS_dl_get_list returns no handles.
+ * v5 restores the debugger authid step used by etaHEN's original fps_elf
+ *    before cross-process dynlib access, while recording before/after counts.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
@@ -40,11 +42,18 @@ int sceKernelSendNotificationRequest(
     notify_request_t* request,
     std::size_t request_size,
     int flags);
+
+// Keep etaHEN's ucred header out of this translation unit because it pulls in
+// FreeBSD kernel structure definitions that conflict with the SDK sysctl
+// headers. The implementations are linked from fps_elf/src/ucred.cpp.
+std::uintptr_t set_ucred_to_debugger();
+std::uintptr_t set_proc_authid(pid_t pid, std::uintptr_t new_authid);
 }
 
 namespace {
 
 constexpr const char* kLogPath = "/data/CommonFPS_v1_probe.log";
+constexpr std::uintptr_t kDebuggerAuthId = 0x4800000000000006ull;
 FILE* g_log = nullptr;
 
 void log_line(const char* fmt, ...) {
@@ -65,6 +74,18 @@ void notify(const char* message) {
     log_line("NOTIFY rc=%d text=%s", rc, message);
 }
 
+void log_dynlib_count(const char* label, common_fps::ProcessId pid) {
+    using namespace common_fps::ps5;
+    std::size_t handle_count = 0;
+    const long rc = syscall(kSysDlGetList, pid, nullptr, 0, &handle_count);
+    log_line(
+        "%s pid=%d rc=%ld count=%llu",
+        label,
+        pid,
+        rc,
+        static_cast<unsigned long long>(handle_count));
+}
+
 void log_dynlib_scan(common_fps::ProcessId pid) {
     using namespace common_fps::ps5;
 
@@ -74,7 +95,7 @@ void log_dynlib_scan(common_fps::ProcessId pid) {
         "S2RAW get_list(count) rc=%ld count=%llu",
         count_rc,
         static_cast<unsigned long long>(handle_count));
-    if (count_rc < 0 || handle_count == 0)
+    if (handle_count == 0)
         return;
 
     std::vector<std::uintptr_t> handles(handle_count);
@@ -86,14 +107,14 @@ void log_dynlib_scan(common_fps::ProcessId pid) {
         list_rc,
         static_cast<unsigned long long>(returned_count),
         static_cast<unsigned long long>(handles.size()));
-    if (list_rc < 0)
+    if (returned_count == 0)
         return;
 
     returned_count = std::min(returned_count, handles.size());
     for (std::size_t i = 0; i < returned_count; ++i) {
         DynlibModuleInfo info{};
         const long info_rc = syscall(kSysDlGetInfo2, pid, 1, handles[i], &info);
-        if (info_rc < 0) {
+        if (info_rc != 0) {
             if (i < 8) {
                 log_line(
                     "S2RAW[%llu] info rc=%ld handle=0x%llx",
@@ -120,16 +141,26 @@ void log_dynlib_scan(common_fps::ProcessId pid) {
     }
 }
 
+void restore_authid(std::uintptr_t old_authid) {
+    if (old_authid == 0)
+        return;
+    const auto replaced = set_proc_authid(getpid(), old_authid);
+    log_line(
+        "S2AUTH restore old=0x%llx replaced=0x%llx",
+        static_cast<unsigned long long>(old_authid),
+        static_cast<unsigned long long>(replaced));
+}
+
 } // namespace
 
 int main() {
     g_log = std::fopen(kLogPath, "w");
     if (g_log) {
         std::setvbuf(g_log, nullptr, _IONBF, 0);
-        log_line("S0 main entered v4");
+        log_line("S0 main entered v5");
     }
 
-    notify("Common FPS parity probe v4\nSTART");
+    notify("Common FPS parity probe v5\nSTART");
 
     common_fps::ps5::V1StablePs5Platform platform;
     std::optional<common_fps::ProcessId> pid;
@@ -144,18 +175,39 @@ int main() {
 
     if (!pid) {
         log_line("FAIL S1 sysctl game process not found after 30s");
-        notify("Common FPS parity probe v4\nFAIL S1: game not found");
+        notify("Common FPS parity probe v5\nFAIL S1: game not found");
         if (g_log) std::fclose(g_log);
         return 11;
     }
     log_line("S1 game pid=%d", *pid);
 
+    // FW 9.60 v4 returned rc=1/count=0 for the target game. Compare the same
+    // syscall against our own process, then reproduce etaHEN fps_elf's
+    // set_ucred_to_debugger() step before touching the target process again.
+    log_dynlib_count("S2AUTH self-before", getpid());
+    log_dynlib_count("S2AUTH game-before", *pid);
+
+    const std::uintptr_t old_authid = set_ucred_to_debugger();
+    log_line(
+        "S2AUTH debugger set old=0x%llx target=0x%llx",
+        static_cast<unsigned long long>(old_authid),
+        static_cast<unsigned long long>(kDebuggerAuthId));
+
+    if (old_authid == 0) {
+        log_line("FAIL S2AUTH could not acquire debugger authid");
+        notify("Common FPS parity probe v5\nFAIL S2AUTH: debugger auth");
+        if (g_log) std::fclose(g_log);
+        return 16;
+    }
+
+    log_dynlib_count("S2AUTH game-after", *pid);
     log_dynlib_scan(*pid);
 
     const auto module = platform.find_module(*pid, "libSceVideoOut.sprx");
     if (!module || module->base == 0) {
         log_line("FAIL S2 libSceVideoOut.sprx not found");
-        notify("Common FPS parity probe v4\nFAIL S2: VideoOut module");
+        notify("Common FPS parity probe v5\nFAIL S2: VideoOut module");
+        restore_authid(old_authid);
         if (g_log) std::fclose(g_log);
         return 12;
     }
@@ -182,7 +234,8 @@ int main() {
         static_cast<unsigned long long>(table.size()));
 
     if (!table_ok) {
-        notify("Common FPS parity probe v4\nFAIL S3: DMAP table read");
+        notify("Common FPS parity probe v5\nFAIL S3: DMAP table read");
+        restore_authid(old_authid);
         if (g_log) std::fclose(g_log);
         return 13;
     }
@@ -193,7 +246,8 @@ int main() {
             "FAIL S4 sampler attach sdk=0x%08x dmap=0x%llx",
             dmap.last_sdk_version(),
             static_cast<unsigned long long>(dmap.last_dmap_base()));
-        notify("Common FPS parity probe v4\nFAIL S4: sampler attach");
+        notify("Common FPS parity probe v5\nFAIL S4: sampler attach");
+        restore_authid(old_authid);
         if (g_log) std::fclose(g_log);
         return 14;
     }
@@ -210,9 +264,10 @@ int main() {
             std::snprintf(
                 message,
                 sizeof(message),
-                "Common FPS parity probe v4\nDMAP FW 9.60 OK: %.1f FPS",
+                "Common FPS parity probe v5\nDMAP FW 9.60 OK: %.1f FPS",
                 *fps);
             notify(message);
+            restore_authid(old_authid);
             platform.sleep_ms(1500);
             if (g_log) std::fclose(g_log);
             return 0;
@@ -228,7 +283,8 @@ int main() {
     }
 
     log_line("FAIL S5 no valid FPS");
-    notify("Common FPS parity probe v4\nFAIL S5: no valid FPS");
+    notify("Common FPS parity probe v5\nFAIL S5: no valid FPS");
+    restore_authid(old_authid);
     if (g_log) std::fclose(g_log);
     return 15;
 }

--- a/src/ps5/v1_parity_probe_main.cpp
+++ b/src/ps5/v1_parity_probe_main.cpp
@@ -1,19 +1,22 @@
 /*
  * Common FPS for PS5
- * Hardware parity probe for the reconstructed stable v1.0.0 FPS sampler.
+ * Hardware parity probe v2 for the reconstructed stable v1.0.0 FPS sampler.
  *
  * This diagnostic ELF intentionally does not install the ShellUI renderer and
- * does not replace the shipping controller/plugin. It exits after the first
- * valid FPS sample (or after a bounded timeout) so FW 9.60 hardware can verify
- * the PHU-style DMAP read path in isolation.
+ * does not replace the shipping controller/plugin. It writes every completed
+ * stage to /data/CommonFPS_v1_probe.log and flushes immediately, so a silent
+ * notification path cannot hide where FW 9.60 parity stops.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include "common_fps/v1_stable_controller.hpp"
+#include "common_fps/constants.hpp"
+#include "common_fps/v1_stable_sampler.hpp"
 #include "v1_stable_ps5_platform.hpp"
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 
@@ -33,64 +36,146 @@ int sceKernelSendNotificationRequest(
 
 namespace {
 
+constexpr const char* kLogPath = "/data/CommonFPS_v1_probe.log";
+
+FILE* g_log = nullptr;
+
+void log_line(const char* fmt, ...) {
+    if (!g_log)
+        return;
+
+    va_list args;
+    va_start(args, fmt);
+    std::vfprintf(g_log, fmt, args);
+    va_end(args);
+    std::fputc('\n', g_log);
+    std::fflush(g_log);
+}
+
 void notify(const char* message) {
     notify_request_t request{};
     std::snprintf(request.message, sizeof(request.message), "%s", message);
-    sceKernelSendNotificationRequest(0, &request, sizeof(request), 0);
+    const int rc = sceKernelSendNotificationRequest(
+        0, &request, sizeof(request), 0);
+    log_line("NOTIFY rc=%d text=%s", rc, message);
 }
-
-class ParityProbeSink final : public common_fps::v1_stable::PacketSink {
-public:
-    bool send(const common_fps::v1_stable::FpsPacket& packet) override {
-        if (done_)
-            return true;
-
-        if (packet.magic != common_fps::v1_stable::kWireMagic ||
-            packet.version != common_fps::v1_stable::kWireVersion) {
-            return false;
-        }
-
-        // Loading packets carry text. Numeric stable-v1 packets leave it empty.
-        if (packet.text[0] != '\0')
-            return true;
-
-        char message[192]{};
-        std::snprintf(
-            message,
-            sizeof(message),
-            "Common FPS parity probe\nDMAP FW 9.60 OK: %.1f FPS",
-            packet.fps);
-        notify(message);
-        done_ = true;
-        return true;
-    }
-
-    [[nodiscard]] bool done() const noexcept { return done_; }
-
-private:
-    bool done_ = false;
-};
 
 } // namespace
 
 int main() {
-    common_fps::ps5::V1StablePs5Platform platform;
-    ParityProbeSink sink;
-    common_fps::v1_stable::Controller controller(platform, sink);
-
-    // Controller::tick() is the reconstructed stable one-second lifecycle.
-    // 90 iterations gives enough time to launch the probe just before a game.
-    for (unsigned attempt = 0; attempt < 90 && !sink.done(); ++attempt)
-        controller.tick();
-
-    if (!sink.done()) {
-        notify(
-            "Common FPS parity probe\n"
-            "No valid FPS after 90 seconds");
-        return 2;
+    g_log = std::fopen(kLogPath, "w");
+    if (g_log) {
+        std::setvbuf(g_log, nullptr, _IONBF, 0);
+        log_line("S0 main entered");
     }
 
-    // Keep the payload alive briefly so the notification request is consumed.
-    platform.sleep_ms(1500);
-    return 0;
+    notify("Common FPS parity probe v2\nSTART");
+
+    common_fps::ps5::V1StablePs5Platform platform;
+
+    std::optional<common_fps::ProcessId> pid;
+    for (unsigned attempt = 0; attempt < 30; ++attempt) {
+        pid = platform.find_game_process();
+        if (pid)
+            break;
+        if (attempt == 0)
+            log_line("S1 waiting for eboot.bin");
+        platform.sleep_ms(1000);
+    }
+
+    if (!pid) {
+        log_line("FAIL S1 game process not found after 30s");
+        notify("Common FPS parity probe v2\nFAIL S1: game not found");
+        if (g_log)
+            std::fclose(g_log);
+        return 11;
+    }
+    log_line("S1 game pid=%d", *pid);
+
+    const auto module = platform.find_module(*pid, "libSceVideoOut.sprx");
+    if (!module || module->base == 0) {
+        log_line("FAIL S2 libSceVideoOut.sprx not found");
+        notify("Common FPS parity probe v2\nFAIL S2: VideoOut module");
+        if (g_log)
+            std::fclose(g_log);
+        return 12;
+    }
+    log_line(
+        "S2 VideoOut base=0x%llx",
+        static_cast<unsigned long long>(module->base));
+
+    constexpr std::size_t kTableSize =
+        common_fps::kVideoOutProbeEntryCount *
+        common_fps::kVideoOutProbeEntrySize;
+    std::array<std::uint8_t, kTableSize> table{};
+
+    const auto table_address =
+        module->base + common_fps::kVideoOutProbeTableOffset;
+    const bool table_ok = platform.read_memory(
+        *pid, table_address, table.data(), table.size());
+
+    const auto& dmap = platform.dmap_backend();
+    log_line(
+        "S3 DMAP table_read=%s sdk=0x%08x dmap=0x%llx addr=0x%llx size=0x%llx",
+        table_ok ? "OK" : "FAIL",
+        dmap.last_sdk_version(),
+        static_cast<unsigned long long>(dmap.last_dmap_base()),
+        static_cast<unsigned long long>(table_address),
+        static_cast<unsigned long long>(table.size()));
+
+    if (!table_ok) {
+        notify("Common FPS parity probe v2\nFAIL S3: DMAP table read");
+        if (g_log)
+            std::fclose(g_log);
+        return 13;
+    }
+
+    common_fps::v1_stable::Sampler sampler(platform);
+    if (!sampler.attach(*pid)) {
+        log_line(
+            "FAIL S4 sampler attach sdk=0x%08x dmap=0x%llx",
+            dmap.last_sdk_version(),
+            static_cast<unsigned long long>(dmap.last_dmap_base()));
+        notify("Common FPS parity probe v2\nFAIL S4: sampler attach");
+        if (g_log)
+            std::fclose(g_log);
+        return 14;
+    }
+
+    log_line(
+        "S4 sampler attached counter=0x%llx",
+        static_cast<unsigned long long>(sampler.counter_address()));
+
+    for (unsigned attempt = 0; attempt < 15; ++attempt) {
+        const auto fps = sampler.sample();
+        if (fps) {
+            log_line("S5 FPS OK value=%.3f", *fps);
+            char message[192]{};
+            std::snprintf(
+                message,
+                sizeof(message),
+                "Common FPS parity probe v2\nDMAP FW 9.60 OK: %.1f FPS",
+                *fps);
+            notify(message);
+            platform.sleep_ms(1500);
+            if (g_log)
+                std::fclose(g_log);
+            return 0;
+        }
+
+        log_line(
+            "S5 sample %u no-value attached=%s",
+            attempt + 1,
+            sampler.attached() ? "yes" : "no");
+
+        if (!sampler.attached())
+            break;
+        platform.sleep_ms(1000);
+    }
+
+    log_line("FAIL S5 no valid FPS");
+    notify("Common FPS parity probe v2\nFAIL S5: no valid FPS");
+    if (g_log)
+        std::fclose(g_log);
+    return 15;
 }

--- a/src/ps5/v1_parity_probe_main.cpp
+++ b/src/ps5/v1_parity_probe_main.cpp
@@ -15,6 +15,7 @@
 #include "v1_stable_ps5_platform.hpp"
 
 #include <array>
+#include <cstdarg>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>

--- a/src/ps5/v1_parity_probe_main.cpp
+++ b/src/ps5/v1_parity_probe_main.cpp
@@ -1,0 +1,96 @@
+/*
+ * Common FPS for PS5
+ * Hardware parity probe for the reconstructed stable v1.0.0 FPS sampler.
+ *
+ * This diagnostic ELF intentionally does not install the ShellUI renderer and
+ * does not replace the shipping controller/plugin. It exits after the first
+ * valid FPS sample (or after a bounded timeout) so FW 9.60 hardware can verify
+ * the PHU-style DMAP read path in isolation.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "common_fps/v1_stable_controller.hpp"
+#include "v1_stable_ps5_platform.hpp"
+
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+
+typedef struct notify_request {
+    char padding[45];
+    char message[3075];
+} notify_request_t;
+
+int sceKernelSendNotificationRequest(
+    int device,
+    notify_request_t* request,
+    std::size_t request_size,
+    int flags);
+}
+
+namespace {
+
+void notify(const char* message) {
+    notify_request_t request{};
+    std::snprintf(request.message, sizeof(request.message), "%s", message);
+    sceKernelSendNotificationRequest(0, &request, sizeof(request), 0);
+}
+
+class ParityProbeSink final : public common_fps::v1_stable::PacketSink {
+public:
+    bool send(const common_fps::v1_stable::FpsPacket& packet) override {
+        if (done_)
+            return true;
+
+        if (packet.magic != common_fps::v1_stable::kWireMagic ||
+            packet.version != common_fps::v1_stable::kWireVersion) {
+            return false;
+        }
+
+        // Loading packets carry text. Numeric stable-v1 packets leave it empty.
+        if (packet.text[0] != '\0')
+            return true;
+
+        char message[192]{};
+        std::snprintf(
+            message,
+            sizeof(message),
+            "Common FPS parity probe\nDMAP FW 9.60 OK: %.1f FPS",
+            packet.fps);
+        notify(message);
+        done_ = true;
+        return true;
+    }
+
+    [[nodiscard]] bool done() const noexcept { return done_; }
+
+private:
+    bool done_ = false;
+};
+
+} // namespace
+
+int main() {
+    common_fps::ps5::V1StablePs5Platform platform;
+    ParityProbeSink sink;
+    common_fps::v1_stable::Controller controller(platform, sink);
+
+    // Controller::tick() is the reconstructed stable one-second lifecycle.
+    // 90 iterations gives enough time to launch the probe just before a game.
+    for (unsigned attempt = 0; attempt < 90 && !sink.done(); ++attempt)
+        controller.tick();
+
+    if (!sink.done()) {
+        notify(
+            "Common FPS parity probe\n"
+            "No valid FPS after 90 seconds");
+        return 2;
+    }
+
+    // Keep the payload alive briefly so the notification request is consumed.
+    platform.sleep_ms(1500);
+    return 0;
+}

--- a/src/ps5/v1_parity_probe_main.cpp
+++ b/src/ps5/v1_parity_probe_main.cpp
@@ -1,11 +1,14 @@
 /*
  * Common FPS for PS5
- * Hardware parity probe v2 for the reconstructed stable v1.0.0 FPS sampler.
+ * Hardware parity probe v3 for the reconstructed stable v1.0.0 FPS sampler.
  *
  * This diagnostic ELF intentionally does not install the ShellUI renderer and
  * does not replace the shipping controller/plugin. It writes every completed
  * stage to /data/CommonFPS_v1_probe.log and flushes immediately, so a silent
  * notification path cannot hide where FW 9.60 parity stops.
+ *
+ * v3 restores the stable line's sysctl/find_pid game discovery instead of the
+ * later clean rewrite's etaHEN allproc helper.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
@@ -67,10 +70,10 @@ int main() {
     g_log = std::fopen(kLogPath, "w");
     if (g_log) {
         std::setvbuf(g_log, nullptr, _IONBF, 0);
-        log_line("S0 main entered");
+        log_line("S0 main entered v3");
     }
 
-    notify("Common FPS parity probe v2\nSTART");
+    notify("Common FPS parity probe v3\nSTART");
 
     common_fps::ps5::V1StablePs5Platform platform;
 
@@ -80,13 +83,13 @@ int main() {
         if (pid)
             break;
         if (attempt == 0)
-            log_line("S1 waiting for eboot.bin");
+            log_line("S1 waiting for eboot.bin via sysctl");
         platform.sleep_ms(1000);
     }
 
     if (!pid) {
-        log_line("FAIL S1 game process not found after 30s");
-        notify("Common FPS parity probe v2\nFAIL S1: game not found");
+        log_line("FAIL S1 sysctl game process not found after 30s");
+        notify("Common FPS parity probe v3\nFAIL S1: game not found");
         if (g_log)
             std::fclose(g_log);
         return 11;
@@ -96,7 +99,7 @@ int main() {
     const auto module = platform.find_module(*pid, "libSceVideoOut.sprx");
     if (!module || module->base == 0) {
         log_line("FAIL S2 libSceVideoOut.sprx not found");
-        notify("Common FPS parity probe v2\nFAIL S2: VideoOut module");
+        notify("Common FPS parity probe v3\nFAIL S2: VideoOut module");
         if (g_log)
             std::fclose(g_log);
         return 12;
@@ -125,7 +128,7 @@ int main() {
         static_cast<unsigned long long>(table.size()));
 
     if (!table_ok) {
-        notify("Common FPS parity probe v2\nFAIL S3: DMAP table read");
+        notify("Common FPS parity probe v3\nFAIL S3: DMAP table read");
         if (g_log)
             std::fclose(g_log);
         return 13;
@@ -137,7 +140,7 @@ int main() {
             "FAIL S4 sampler attach sdk=0x%08x dmap=0x%llx",
             dmap.last_sdk_version(),
             static_cast<unsigned long long>(dmap.last_dmap_base()));
-        notify("Common FPS parity probe v2\nFAIL S4: sampler attach");
+        notify("Common FPS parity probe v3\nFAIL S4: sampler attach");
         if (g_log)
             std::fclose(g_log);
         return 14;
@@ -155,7 +158,7 @@ int main() {
             std::snprintf(
                 message,
                 sizeof(message),
-                "Common FPS parity probe v2\nDMAP FW 9.60 OK: %.1f FPS",
+                "Common FPS parity probe v3\nDMAP FW 9.60 OK: %.1f FPS",
                 *fps);
             notify(message);
             platform.sleep_ms(1500);
@@ -175,7 +178,7 @@ int main() {
     }
 
     log_line("FAIL S5 no valid FPS");
-    notify("Common FPS parity probe v2\nFAIL S5: no valid FPS");
+    notify("Common FPS parity probe v3\nFAIL S5: no valid FPS");
     if (g_log)
         std::fclose(g_log);
     return 15;

--- a/src/ps5/v1_stable_dmap_backend.cpp
+++ b/src/ps5/v1_stable_dmap_backend.cpp
@@ -6,6 +6,7 @@
  */
 #include "v1_stable_dmap_backend.hpp"
 
+#include <sys/types.h>
 #include <sys/sysctl.h>
 
 extern "C" {

--- a/src/ps5/v1_stable_dmap_backend.cpp
+++ b/src/ps5/v1_stable_dmap_backend.cpp
@@ -1,0 +1,169 @@
+/*
+ * Common FPS for PS5
+ * Stable v1.0.0 DMAP reader reconstruction for FW 9.60.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include "v1_stable_dmap_backend.hpp"
+
+#include <sys/sysctl.h>
+
+extern "C" {
+unsigned long kernel_get_proc(int pid);
+int kernel_copyout(unsigned long kaddr, void* uaddr, unsigned long len);
+}
+
+namespace common_fps::ps5 {
+namespace {
+
+/*
+ * FW 9.60 values cross-checked against Team PHU's public
+ * PS5-PHU-Trophy-System/src/phu_fw_offsets.c and the r11 donor.
+ */
+constexpr std::uint32_t kFw960Min = 0x09600000u;
+constexpr std::uint32_t kFw960Max = 0x0960ffffu;
+
+constexpr std::uintptr_t kProcVmspaceOffset = 0x200;
+constexpr std::uintptr_t kVmspacePmapOffset = 0x1d8;
+constexpr std::uintptr_t kPmapPml4Offset = 0x20;
+constexpr std::uintptr_t kPmapCr3Offset = 0x28;
+
+constexpr std::uintptr_t kPhysicalPageMask = 0x000ffffffffff000ull;
+constexpr std::uintptr_t kFw9DmapFallback = 0xffff873b00000000ull;
+
+bool plausible_kernel_dmap(std::uintptr_t value) noexcept {
+    return (value & 0xffff000000000000ull) == 0xffff000000000000ull;
+}
+
+} // namespace
+
+std::uint32_t V1StableDmapBackend::current_sdk_version() const {
+    std::uint32_t sdk = 0;
+    size_t size = sizeof(sdk);
+    if (sysctlbyname("kern.sdk_version", &sdk, &size, nullptr, 0) != 0)
+        return 0;
+    if (size != sizeof(sdk))
+        return 0;
+    return sdk;
+}
+
+bool V1StableDmapBackend::kernel_read_u64(
+    std::uintptr_t kernel_address,
+    std::uint64_t& value) const {
+
+    value = 0;
+    return kernel_copyout(
+               static_cast<unsigned long>(kernel_address),
+               &value,
+               sizeof(value)) == 0;
+}
+
+bool V1StableDmapBackend::prepare_process_translation(
+    ProcessId pid,
+    std::uintptr_t& cr3_physical) {
+
+    dmap_base_ = 0;
+    cr3_physical = 0;
+
+    last_sdk_version_ = current_sdk_version();
+    if (last_sdk_version_ < kFw960Min || last_sdk_version_ > kFw960Max)
+        return false;
+
+    const auto proc = static_cast<std::uintptr_t>(kernel_get_proc(pid));
+    if (proc == 0)
+        return false;
+
+    std::uint64_t vmspace = 0;
+    std::uint64_t pmap = 0;
+    std::uint64_t pml4_virtual = 0;
+    std::uint64_t cr3 = 0;
+
+    if (!kernel_read_u64(proc + kProcVmspaceOffset, vmspace) || vmspace == 0)
+        return false;
+
+    if (!kernel_read_u64(
+            static_cast<std::uintptr_t>(vmspace) + kVmspacePmapOffset,
+            pmap) || pmap == 0) {
+        return false;
+    }
+
+    if (!kernel_read_u64(
+            static_cast<std::uintptr_t>(pmap) + kPmapPml4Offset,
+            pml4_virtual)) {
+        return false;
+    }
+
+    if (!kernel_read_u64(
+            static_cast<std::uintptr_t>(pmap) + kPmapCr3Offset,
+            cr3) || cr3 == 0) {
+        return false;
+    }
+
+    const auto cr3_page =
+        static_cast<std::uintptr_t>(cr3) & kPhysicalPageMask;
+    cr3_physical = cr3_page;
+
+    /*
+     * PHU derives the direct-map base from pm_pml4 - pm_cr3. Keep that as the
+     * primary path. The published 9.x fallback is used only if derivation is
+     * unavailable or produces a non-kernel-canonical address.
+     */
+    if (pml4_virtual >= cr3_page && cr3_page != 0) {
+        const auto derived =
+            static_cast<std::uintptr_t>(pml4_virtual) - cr3_page;
+        if (plausible_kernel_dmap(derived))
+            dmap_base_ = derived;
+    }
+
+    if (dmap_base_ == 0)
+        dmap_base_ = kFw9DmapFallback;
+
+    return dmap_base_ != 0 && cr3_physical != 0;
+}
+
+bool V1StableDmapBackend::read_entry(
+    std::uintptr_t physical_address,
+    std::uint64_t& value) {
+
+    if (dmap_base_ == 0)
+        return false;
+
+    value = 0;
+    return kernel_copyout(
+               static_cast<unsigned long>(dmap_base_ + physical_address),
+               &value,
+               sizeof(value)) == 0;
+}
+
+std::optional<common_fps::v1_stable::PageTranslation>
+V1StableDmapBackend::translate(
+    ProcessId pid,
+    std::uintptr_t virtual_address) {
+
+    std::uintptr_t cr3_physical = 0;
+    if (!prepare_process_translation(pid, cr3_physical))
+        return std::nullopt;
+
+    return common_fps::v1_stable::translate_x86_64(
+        *this,
+        cr3_physical,
+        virtual_address);
+}
+
+bool V1StableDmapBackend::copy_physical(
+    std::uintptr_t physical_address,
+    void* output,
+    std::size_t size) {
+
+    if (size == 0)
+        return true;
+    if (dmap_base_ == 0 || output == nullptr)
+        return false;
+
+    return kernel_copyout(
+               static_cast<unsigned long>(dmap_base_ + physical_address),
+               output,
+               static_cast<unsigned long>(size)) == 0;
+}
+
+} // namespace common_fps::ps5

--- a/src/ps5/v1_stable_dmap_backend.hpp
+++ b/src/ps5/v1_stable_dmap_backend.hpp
@@ -1,0 +1,61 @@
+/*
+ * Common FPS for PS5
+ * Stable v1.0.0 DMAP reader reconstruction for FW 9.60.
+ *
+ * Firmware structure offsets cross-checked against Team PHU's public
+ * PS5-PHU-Trophy-System (MIT) and the PHU r11 donor DWARF/disassembly.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include "common_fps/v1_stable_memory.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace common_fps::ps5 {
+
+class V1StableDmapBackend final
+    : public common_fps::v1_stable::DmapReadBackend,
+      private common_fps::v1_stable::PhysicalEntryReader {
+public:
+    V1StableDmapBackend() = default;
+
+    std::optional<common_fps::v1_stable::PageTranslation>
+    translate(ProcessId pid, std::uintptr_t virtual_address) override;
+
+    bool copy_physical(
+        std::uintptr_t physical_address,
+        void* output,
+        std::size_t size) override;
+
+    [[nodiscard]] std::uint32_t last_sdk_version() const noexcept {
+        return last_sdk_version_;
+    }
+
+    [[nodiscard]] std::uintptr_t last_dmap_base() const noexcept {
+        return dmap_base_;
+    }
+
+private:
+    bool read_entry(
+        std::uintptr_t physical_address,
+        std::uint64_t& value) override;
+
+    bool prepare_process_translation(
+        ProcessId pid,
+        std::uintptr_t& cr3_physical);
+
+    bool kernel_read_u64(
+        std::uintptr_t kernel_address,
+        std::uint64_t& value) const;
+
+    std::uint32_t current_sdk_version() const;
+
+    std::uint32_t last_sdk_version_ = 0;
+    std::uintptr_t dmap_base_ = 0;
+};
+
+} // namespace common_fps::ps5

--- a/src/ps5/v1_stable_dynlib.hpp
+++ b/src/ps5/v1_stable_dynlib.hpp
@@ -1,0 +1,49 @@
+/*
+ * Common FPS for PS5
+ * Minimal target-process dynlib ABI used by stable-v1 reconstruction.
+ * Layout mirrors the public etaHEN fps_elf module_info_t definition without
+ * pulling etaHEN's kernel structure headers into the sysctl translation unit.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace common_fps::ps5 {
+
+inline constexpr long kSysDlGetList = 0x217;
+inline constexpr long kSysDlGetInfo2 = 0x2cd;
+
+inline constexpr std::size_t kDynlibNameLength = 128;
+inline constexpr std::size_t kDynlibSandboxPathLength = 1024;
+inline constexpr std::size_t kDynlibMaxSections = 4;
+inline constexpr std::size_t kDynlibFingerprintLength = 20;
+
+struct DynlibModuleSection {
+    std::uint64_t vaddr;
+    std::uint32_t size;
+    std::uint32_t prot;
+};
+
+struct DynlibModuleInfo {
+    char filename[kDynlibNameLength];
+    std::uint64_t handle;
+    std::uint8_t unknown0[32];
+    std::uint64_t init;
+    std::uint64_t fini;
+    std::uint64_t eh_frame_hdr;
+    std::uint64_t eh_frame_hdr_sz;
+    std::uint64_t eh_frame;
+    std::uint64_t eh_frame_sz;
+    DynlibModuleSection sections[kDynlibMaxSections];
+    std::uint8_t unknown7[1176];
+    std::uint8_t fingerprint[kDynlibFingerprintLength];
+    std::uint32_t unknown8;
+    char libname[kDynlibNameLength];
+    std::uint32_t unknown9;
+    char sandboxed_path[kDynlibSandboxPathLength];
+    std::uint64_t sdk_version;
+};
+
+} // namespace common_fps::ps5

--- a/src/ps5/v1_stable_ps5_platform.cpp
+++ b/src/ps5/v1_stable_ps5_platform.cpp
@@ -7,14 +7,122 @@
 
 #include "common_fps/v1_stable_memory.hpp"
 
+#include <cstdint>
+#include <cstring>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#include <vector>
+
 namespace common_fps::ps5 {
+namespace {
+
+/*
+ * Hardware-parity process discovery.
+ *
+ * The stable Common FPS line (v0.7 -> v0.17 -> v0.22c -> v1.0.0) found the
+ * foreground game through the ordinary PS5/FreeBSD KERN_PROC sysctl snapshot.
+ * Do not replace this with etaHEN's allproc find_proc_by_name(): the latter was
+ * introduced only by the later clean rewrite and failed the FW 9.60 parity
+ * probe even while eboot.bin was already running.
+ */
+std::optional<ProcessId> find_process_sysctl(const char* process_name) {
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0};
+
+    std::size_t buffer_size = 0;
+    if (sysctl(mib, 4, nullptr, &buffer_size, nullptr, 0) != 0 ||
+        buffer_size == 0) {
+        return std::nullopt;
+    }
+
+    std::vector<std::uint8_t> buffer(buffer_size);
+    if (sysctl(
+            mib,
+            4,
+            buffer.data(),
+            &buffer_size,
+            nullptr,
+            0) != 0) {
+        return std::nullopt;
+    }
+
+    auto* cursor = buffer.data();
+    auto* end = buffer.data() + buffer_size;
+
+    while (cursor + sizeof(int) <= end) {
+        const auto* info = reinterpret_cast<const struct kinfo_proc*>(cursor);
+        const auto record_size = static_cast<std::size_t>(info->ki_structsize);
+
+        if (record_size < sizeof(struct kinfo_proc) ||
+            record_size > static_cast<std::size_t>(end - cursor)) {
+            break;
+        }
+
+        if (info->ki_pid > 0 &&
+            std::strncmp(
+                info->ki_comm,
+                process_name,
+                sizeof(info->ki_comm)) == 0) {
+            return static_cast<ProcessId>(info->ki_pid);
+        }
+
+        cursor += record_size;
+    }
+
+    return std::nullopt;
+}
+
+bool process_alive_sysctl(ProcessId pid) {
+    if (pid <= 0)
+        return false;
+
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0};
+
+    std::size_t buffer_size = 0;
+    if (sysctl(mib, 4, nullptr, &buffer_size, nullptr, 0) != 0 ||
+        buffer_size == 0) {
+        return false;
+    }
+
+    std::vector<std::uint8_t> buffer(buffer_size);
+    if (sysctl(
+            mib,
+            4,
+            buffer.data(),
+            &buffer_size,
+            nullptr,
+            0) != 0) {
+        return false;
+    }
+
+    auto* cursor = buffer.data();
+    auto* end = buffer.data() + buffer_size;
+
+    while (cursor + sizeof(int) <= end) {
+        const auto* info = reinterpret_cast<const struct kinfo_proc*>(cursor);
+        const auto record_size = static_cast<std::size_t>(info->ki_structsize);
+
+        if (record_size < sizeof(struct kinfo_proc) ||
+            record_size > static_cast<std::size_t>(end - cursor)) {
+            break;
+        }
+
+        if (info->ki_pid == pid)
+            return true;
+
+        cursor += record_size;
+    }
+
+    return false;
+}
+
+} // namespace
 
 std::optional<ProcessId> V1StablePs5Platform::find_game_process() {
-    return base_.find_game_process();
+    return find_process_sysctl("eboot.bin");
 }
 
 bool V1StablePs5Platform::process_alive(ProcessId pid) {
-    return base_.process_alive(pid);
+    return process_alive_sysctl(pid);
 }
 
 std::optional<ModuleInfo>

--- a/src/ps5/v1_stable_ps5_platform.cpp
+++ b/src/ps5/v1_stable_ps5_platform.cpp
@@ -7,12 +7,18 @@
 
 #include "common_fps/v1_stable_memory.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/user.h>
+#include <unistd.h>
 #include <vector>
+
+extern "C" {
+#include "proc.h"
+}
 
 namespace common_fps::ps5 {
 namespace {
@@ -116,6 +122,73 @@ bool process_alive_sysctl(ProcessId pid) {
     return false;
 }
 
+bool module_name_matches(const char* reported, const char* requested) {
+    if (!reported || !requested || !reported[0] || !requested[0])
+        return false;
+
+    if (std::strcmp(reported, requested) == 0)
+        return true;
+
+    const char* basename = std::strrchr(reported, '/');
+    basename = basename ? basename + 1 : reported;
+    if (std::strcmp(basename, requested) == 0)
+        return true;
+
+    const std::size_t reported_len = std::strlen(reported);
+    const std::size_t requested_len = std::strlen(requested);
+    return reported_len >= requested_len &&
+           std::strcmp(reported + reported_len - requested_len, requested) == 0;
+}
+
+/*
+ * Stable module discovery uses the target process' dynlib handle list.
+ * etaHEN's helper compared module_info_t::filename with strcmp(), which is too
+ * strict for FW 9.60 if the kernel reports a full module path. Keep the same
+ * syscalls but compare the basename/suffix as well.
+ */
+std::optional<ModuleInfo>
+find_module_dynlib(ProcessId pid, const char* module_name) {
+    std::size_t handle_count = 0;
+    if (syscall(SYS_dl_get_list, pid, nullptr, 0, &handle_count) < 0 ||
+        handle_count == 0) {
+        return std::nullopt;
+    }
+
+    std::vector<std::uintptr_t> handles(handle_count);
+    std::size_t returned_count = handle_count;
+    if (syscall(
+            SYS_dl_get_list,
+            pid,
+            handles.data(),
+            handles.size(),
+            &returned_count) < 0) {
+        return std::nullopt;
+    }
+
+    returned_count = std::min(returned_count, handles.size());
+    for (std::size_t i = 0; i < returned_count; ++i) {
+        module_info_t info{};
+        if (syscall(
+                SYS_dl_get_info_2,
+                pid,
+                1,
+                handles[i],
+                &info) < 0) {
+            continue;
+        }
+
+        if (!module_name_matches(info.filename, module_name))
+            continue;
+
+        ModuleInfo result;
+        result.base = static_cast<std::uintptr_t>(info.sections[0].vaddr);
+        result.name = info.filename;
+        return result;
+    }
+
+    return std::nullopt;
+}
+
 } // namespace
 
 std::optional<ProcessId> V1StablePs5Platform::find_game_process() {
@@ -128,7 +201,7 @@ bool V1StablePs5Platform::process_alive(ProcessId pid) {
 
 std::optional<ModuleInfo>
 V1StablePs5Platform::find_module(ProcessId pid, const char* module_name) {
-    return base_.find_module(pid, module_name);
+    return find_module_dynlib(pid, module_name);
 }
 
 bool V1StablePs5Platform::read_memory(

--- a/src/ps5/v1_stable_ps5_platform.cpp
+++ b/src/ps5/v1_stable_ps5_platform.cpp
@@ -1,0 +1,47 @@
+/*
+ * Common FPS for PS5
+ * Stable v1.0.0 PS5 platform adapter.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include "v1_stable_ps5_platform.hpp"
+
+#include "common_fps/v1_stable_memory.hpp"
+
+namespace common_fps::ps5 {
+
+std::optional<ProcessId> V1StablePs5Platform::find_game_process() {
+    return base_.find_game_process();
+}
+
+bool V1StablePs5Platform::process_alive(ProcessId pid) {
+    return base_.process_alive(pid);
+}
+
+std::optional<ModuleInfo>
+V1StablePs5Platform::find_module(ProcessId pid, const char* module_name) {
+    return base_.find_module(pid, module_name);
+}
+
+bool V1StablePs5Platform::read_memory(
+    ProcessId pid,
+    std::uintptr_t address,
+    void* out,
+    std::size_t size) {
+
+    return common_fps::v1_stable::proc_read_dmap(
+        dmap_,
+        pid,
+        address,
+        out,
+        size);
+}
+
+std::uint64_t V1StablePs5Platform::monotonic_us() {
+    return base_.monotonic_us();
+}
+
+void V1StablePs5Platform::sleep_ms(unsigned milliseconds) {
+    base_.sleep_ms(milliseconds);
+}
+
+} // namespace common_fps::ps5

--- a/src/ps5/v1_stable_ps5_platform.cpp
+++ b/src/ps5/v1_stable_ps5_platform.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 #include "v1_stable_ps5_platform.hpp"
+#include "v1_stable_dynlib.hpp"
 
 #include "common_fps/v1_stable_memory.hpp"
 
@@ -16,65 +17,34 @@
 #include <unistd.h>
 #include <vector>
 
-extern "C" {
-#include "proc.h"
-}
-
 namespace common_fps::ps5 {
 namespace {
 
-/*
- * Hardware-parity process discovery.
- *
- * The stable Common FPS line (v0.7 -> v0.17 -> v0.22c -> v1.0.0) found the
- * foreground game through the ordinary PS5/FreeBSD KERN_PROC sysctl snapshot.
- * Do not replace this with etaHEN's allproc find_proc_by_name(): the latter was
- * introduced only by the later clean rewrite and failed the FW 9.60 parity
- * probe even while eboot.bin was already running.
- */
 std::optional<ProcessId> find_process_sysctl(const char* process_name) {
     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0};
-
     std::size_t buffer_size = 0;
-    if (sysctl(mib, 4, nullptr, &buffer_size, nullptr, 0) != 0 ||
-        buffer_size == 0) {
+    if (sysctl(mib, 4, nullptr, &buffer_size, nullptr, 0) != 0 || buffer_size == 0)
         return std::nullopt;
-    }
 
     std::vector<std::uint8_t> buffer(buffer_size);
-    if (sysctl(
-            mib,
-            4,
-            buffer.data(),
-            &buffer_size,
-            nullptr,
-            0) != 0) {
+    if (sysctl(mib, 4, buffer.data(), &buffer_size, nullptr, 0) != 0)
         return std::nullopt;
-    }
 
     auto* cursor = buffer.data();
     auto* end = buffer.data() + buffer_size;
-
     while (cursor + sizeof(int) <= end) {
         const auto* info = reinterpret_cast<const struct kinfo_proc*>(cursor);
         const auto record_size = static_cast<std::size_t>(info->ki_structsize);
-
         if (record_size < sizeof(struct kinfo_proc) ||
-            record_size > static_cast<std::size_t>(end - cursor)) {
+            record_size > static_cast<std::size_t>(end - cursor))
             break;
-        }
 
         if (info->ki_pid > 0 &&
-            std::strncmp(
-                info->ki_comm,
-                process_name,
-                sizeof(info->ki_comm)) == 0) {
+            std::strncmp(info->ki_comm, process_name, sizeof(info->ki_comm)) == 0)
             return static_cast<ProcessId>(info->ki_pid);
-        }
 
         cursor += record_size;
     }
-
     return std::nullopt;
 }
 
@@ -83,49 +53,32 @@ bool process_alive_sysctl(ProcessId pid) {
         return false;
 
     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0};
-
     std::size_t buffer_size = 0;
-    if (sysctl(mib, 4, nullptr, &buffer_size, nullptr, 0) != 0 ||
-        buffer_size == 0) {
+    if (sysctl(mib, 4, nullptr, &buffer_size, nullptr, 0) != 0 || buffer_size == 0)
         return false;
-    }
 
     std::vector<std::uint8_t> buffer(buffer_size);
-    if (sysctl(
-            mib,
-            4,
-            buffer.data(),
-            &buffer_size,
-            nullptr,
-            0) != 0) {
+    if (sysctl(mib, 4, buffer.data(), &buffer_size, nullptr, 0) != 0)
         return false;
-    }
 
     auto* cursor = buffer.data();
     auto* end = buffer.data() + buffer_size;
-
     while (cursor + sizeof(int) <= end) {
         const auto* info = reinterpret_cast<const struct kinfo_proc*>(cursor);
         const auto record_size = static_cast<std::size_t>(info->ki_structsize);
-
         if (record_size < sizeof(struct kinfo_proc) ||
-            record_size > static_cast<std::size_t>(end - cursor)) {
+            record_size > static_cast<std::size_t>(end - cursor))
             break;
-        }
-
         if (info->ki_pid == pid)
             return true;
-
         cursor += record_size;
     }
-
     return false;
 }
 
 bool module_name_matches(const char* reported, const char* requested) {
     if (!reported || !requested || !reported[0] || !requested[0])
         return false;
-
     if (std::strcmp(reported, requested) == 0)
         return true;
 
@@ -140,43 +93,22 @@ bool module_name_matches(const char* reported, const char* requested) {
            std::strcmp(reported + reported_len - requested_len, requested) == 0;
 }
 
-/*
- * Stable module discovery uses the target process' dynlib handle list.
- * etaHEN's helper compared module_info_t::filename with strcmp(), which is too
- * strict for FW 9.60 if the kernel reports a full module path. Keep the same
- * syscalls but compare the basename/suffix as well.
- */
 std::optional<ModuleInfo>
 find_module_dynlib(ProcessId pid, const char* module_name) {
     std::size_t handle_count = 0;
-    if (syscall(SYS_dl_get_list, pid, nullptr, 0, &handle_count) < 0 ||
-        handle_count == 0) {
+    if (syscall(kSysDlGetList, pid, nullptr, 0, &handle_count) < 0 || handle_count == 0)
         return std::nullopt;
-    }
 
     std::vector<std::uintptr_t> handles(handle_count);
     std::size_t returned_count = handle_count;
-    if (syscall(
-            SYS_dl_get_list,
-            pid,
-            handles.data(),
-            handles.size(),
-            &returned_count) < 0) {
+    if (syscall(kSysDlGetList, pid, handles.data(), handles.size(), &returned_count) < 0)
         return std::nullopt;
-    }
 
     returned_count = std::min(returned_count, handles.size());
     for (std::size_t i = 0; i < returned_count; ++i) {
-        module_info_t info{};
-        if (syscall(
-                SYS_dl_get_info_2,
-                pid,
-                1,
-                handles[i],
-                &info) < 0) {
+        DynlibModuleInfo info{};
+        if (syscall(kSysDlGetInfo2, pid, 1, handles[i], &info) < 0)
             continue;
-        }
-
         if (!module_name_matches(info.filename, module_name))
             continue;
 
@@ -209,13 +141,7 @@ bool V1StablePs5Platform::read_memory(
     std::uintptr_t address,
     void* out,
     std::size_t size) {
-
-    return common_fps::v1_stable::proc_read_dmap(
-        dmap_,
-        pid,
-        address,
-        out,
-        size);
+    return common_fps::v1_stable::proc_read_dmap(dmap_, pid, address, out, size);
 }
 
 std::uint64_t V1StablePs5Platform::monotonic_us() {

--- a/src/ps5/v1_stable_ps5_platform.cpp
+++ b/src/ps5/v1_stable_ps5_platform.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/user.h>
 #include <vector>

--- a/src/ps5/v1_stable_ps5_platform.hpp
+++ b/src/ps5/v1_stable_ps5_platform.hpp
@@ -1,0 +1,45 @@
+/*
+ * Common FPS for PS5
+ * Stable v1.0.0 PS5 platform adapter.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include "common_fps/platform.hpp"
+#include "ps5_platform.hpp"
+#include "v1_stable_dmap_backend.hpp"
+
+namespace common_fps::ps5 {
+
+/*
+ * Process/module discovery and timing stay on the existing etaHEN-backed
+ * Ps5Platform implementation. Only remote game-memory reads are replaced by
+ * the reconstructed PHU DMAP path used by hardware-stable v1.0.0.
+ */
+class V1StablePs5Platform final : public Platform {
+public:
+    std::optional<ProcessId> find_game_process() override;
+    bool process_alive(ProcessId pid) override;
+
+    std::optional<ModuleInfo>
+    find_module(ProcessId pid, const char* module_name) override;
+
+    bool read_memory(
+        ProcessId pid,
+        std::uintptr_t address,
+        void* out,
+        std::size_t size) override;
+
+    std::uint64_t monotonic_us() override;
+    void sleep_ms(unsigned milliseconds) override;
+
+    [[nodiscard]] const V1StableDmapBackend& dmap_backend() const noexcept {
+        return dmap_;
+    }
+
+private:
+    Ps5Platform base_;
+    V1StableDmapBackend dmap_;
+};
+
+} // namespace common_fps::ps5

--- a/src/reconstruction/v1_stable_controller.cpp
+++ b/src/reconstruction/v1_stable_controller.cpp
@@ -1,0 +1,45 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#include "common_fps/v1_stable_controller.hpp"
+
+namespace common_fps::v1_stable {
+
+Controller::Controller(Platform& platform, PacketSink& sink)
+    : platform_(platform), sink_(sink), sampler_(platform) {}
+
+bool Controller::send_loading() {
+    FpsPacket packet{};
+    set_loading(packet, sequence_++);
+    return sink_.send(packet);
+}
+
+bool Controller::tick() {
+    if (!sampler_.attached()) {
+        const auto pid = platform_.find_game_process();
+        if (!pid) {
+            send_loading();
+            platform_.sleep_ms(1000);
+            return true;
+        }
+
+        if (!sampler_.attach(*pid)) {
+            send_loading();
+            platform_.sleep_ms(1000);
+            return true;
+        }
+    }
+
+    const auto fps = sampler_.sample();
+    if (!fps) {
+        send_loading();
+        platform_.sleep_ms(1000);
+        return true;
+    }
+
+    FpsPacket packet{};
+    set_numeric(packet, sequence_++, *fps);
+    sink_.send(packet);
+    platform_.sleep_ms(1000);
+    return true;
+}
+
+} // namespace common_fps::v1_stable

--- a/src/reconstruction/v1_stable_hook_state.cpp
+++ b/src/reconstruction/v1_stable_hook_state.cpp
@@ -1,0 +1,101 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#include "common_fps/v1_stable_hook_state.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+namespace common_fps::v1_stable {
+
+void HookState::store_text(AtomicBuffer& dst, const char* src) {
+    for (auto& byte : dst)
+        byte.store(0, std::memory_order_relaxed);
+
+    if (!src)
+        return;
+
+    const std::size_t len =
+        std::min<std::size_t>(std::strlen(src), kHookTextCapacity - 1);
+
+    for (std::size_t i = 0; i < len; ++i) {
+        dst[i].store(
+            static_cast<unsigned char>(src[i]),
+            std::memory_order_relaxed);
+    }
+    dst[len].store(0, std::memory_order_relaxed);
+}
+
+void HookState::load_text(
+    const AtomicBuffer& src,
+    std::array<char, kHookTextCapacity>& dst) {
+    for (std::size_t i = 0; i < kHookTextCapacity; ++i) {
+        dst[i] = static_cast<char>(
+            src[i].load(std::memory_order_relaxed));
+    }
+    dst.back() = '\0';
+}
+
+void HookState::publish(const char* text, const char* text2) {
+    if (!text || !text2)
+        return;
+
+    // Writer active: sequence becomes odd.
+    sequence_.fetch_add(1, std::memory_order_acq_rel);
+    store_text(text_, text);
+    store_text(text2_, text2);
+    // Publish complete snapshot: sequence becomes even.
+    sequence_.fetch_add(1, std::memory_order_release);
+}
+
+void HookState::publish_raw(const char* text) {
+    if (!text)
+        return;
+
+    raw_sequence_.fetch_add(1, std::memory_order_acq_rel);
+    store_text(raw_text_, text);
+    raw_sequence_.fetch_add(1, std::memory_order_release);
+}
+
+bool HookState::snapshot(TextSnapshot& out, unsigned max_attempts) const {
+    for (unsigned attempt = 0; attempt < max_attempts; ++attempt) {
+        const auto before = sequence_.load(std::memory_order_acquire);
+        if (before & 1u)
+            continue;
+
+        load_text(text_, out.text);
+        load_text(text2_, out.text2);
+
+        const auto after = sequence_.load(std::memory_order_acquire);
+        if (before == after && !(after & 1u)) {
+            out.sequence = after;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool HookState::snapshot_raw(RawSnapshot& out, unsigned max_attempts) const {
+    for (unsigned attempt = 0; attempt < max_attempts; ++attempt) {
+        const auto before = raw_sequence_.load(std::memory_order_acquire);
+        if (before & 1u)
+            continue;
+
+        load_text(raw_text_, out.text);
+
+        const auto after = raw_sequence_.load(std::memory_order_acquire);
+        if (before == after && !(after & 1u)) {
+            out.sequence = after;
+            return true;
+        }
+    }
+    return false;
+}
+
+std::uint64_t HookState::sequence() const noexcept {
+    return sequence_.load(std::memory_order_acquire);
+}
+
+std::uint64_t HookState::raw_sequence() const noexcept {
+    return raw_sequence_.load(std::memory_order_acquire);
+}
+
+} // namespace common_fps::v1_stable

--- a/src/reconstruction/v1_stable_memory.cpp
+++ b/src/reconstruction/v1_stable_memory.cpp
@@ -1,0 +1,57 @@
+/*
+ * Common FPS for PS5
+ * Stable v1.0.0 memory-read behavior reconstructed from PHU r11.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include "common_fps/v1_stable_memory.hpp"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace common_fps::v1_stable {
+
+bool proc_read_dmap(
+    DmapReadBackend& backend,
+    ProcessId pid,
+    std::uintptr_t virtual_address,
+    void* output,
+    std::size_t size) noexcept {
+
+    if (size == 0)
+        return true;
+    if (!output)
+        return false;
+
+    auto* destination = static_cast<std::uint8_t*>(output);
+    std::size_t remaining = size;
+
+    while (remaining != 0) {
+        const auto translation = backend.translate(pid, virtual_address);
+        if (!translation || translation->physical == 0 ||
+            translation->page_size == 0) {
+            return false;
+        }
+
+        const std::size_t page_size = translation->page_size;
+        const std::size_t offset_in_page =
+            static_cast<std::size_t>(virtual_address & (page_size - 1));
+        const std::size_t until_page_end = page_size - offset_in_page;
+        const std::size_t chunk = std::min(remaining, until_page_end);
+
+        if (chunk == 0 ||
+            !backend.copy_physical(
+                translation->physical,
+                destination,
+                chunk)) {
+            return false;
+        }
+
+        virtual_address += chunk;
+        destination += chunk;
+        remaining -= chunk;
+    }
+
+    return true;
+}
+
+} // namespace common_fps::v1_stable

--- a/src/reconstruction/v1_stable_memory.cpp
+++ b/src/reconstruction/v1_stable_memory.cpp
@@ -9,6 +9,99 @@
 #include <cstdint>
 
 namespace common_fps::v1_stable {
+namespace {
+
+constexpr std::uint64_t kPresent = 1ull << 0;
+constexpr std::uint64_t kPageSizeBit = 1ull << 7;
+
+constexpr std::uintptr_t kTableAddressMask = 0x000ffffffffff000ull;
+constexpr std::uintptr_t kPage1GiBAddressMask = 0x000fffffc0000000ull;
+constexpr std::uintptr_t kPage2MiBAddressMask = 0x000fffffffe00000ull;
+constexpr std::uintptr_t kPage4KiBAddressMask = 0x000ffffffffff000ull;
+
+constexpr std::size_t kPage1GiB = 0x40000000ull;
+constexpr std::size_t kPage2MiB = 0x00200000ull;
+constexpr std::size_t kPage4KiB = 0x00001000ull;
+
+constexpr std::uintptr_t table_index(
+    std::uintptr_t virtual_address,
+    unsigned shift) noexcept {
+    return (virtual_address >> shift) & 0x1ffull;
+}
+
+bool read_table_entry(
+    PhysicalEntryReader& reader,
+    std::uintptr_t table_physical,
+    std::uintptr_t index,
+    std::uint64_t& entry) noexcept {
+
+    return reader.read_entry(table_physical + index * sizeof(std::uint64_t), entry);
+}
+
+} // namespace
+
+std::optional<PageTranslation> translate_x86_64(
+    PhysicalEntryReader& reader,
+    std::uintptr_t cr3_physical,
+    std::uintptr_t virtual_address) noexcept {
+
+    // CR3 low twelve bits are PCID / control bits, not part of the PML4 PA.
+    std::uintptr_t table = cr3_physical & kTableAddressMask;
+    if (table == 0)
+        return std::nullopt;
+
+    std::uint64_t entry = 0;
+
+    // PML4E
+    if (!read_table_entry(reader, table, table_index(virtual_address, 39), entry) ||
+        (entry & kPresent) == 0) {
+        return std::nullopt;
+    }
+    table = static_cast<std::uintptr_t>(entry) & kTableAddressMask;
+
+    // PDPTE: PS=1 means a 1 GiB mapping.
+    if (!read_table_entry(reader, table, table_index(virtual_address, 30), entry) ||
+        (entry & kPresent) == 0) {
+        return std::nullopt;
+    }
+    if ((entry & kPageSizeBit) != 0) {
+        const auto physical_base =
+            static_cast<std::uintptr_t>(entry) & kPage1GiBAddressMask;
+        return PageTranslation{
+            physical_base + (virtual_address & (kPage1GiB - 1)),
+            kPage1GiB,
+        };
+    }
+    table = static_cast<std::uintptr_t>(entry) & kTableAddressMask;
+
+    // PDE: PS=1 means a 2 MiB mapping.
+    if (!read_table_entry(reader, table, table_index(virtual_address, 21), entry) ||
+        (entry & kPresent) == 0) {
+        return std::nullopt;
+    }
+    if ((entry & kPageSizeBit) != 0) {
+        const auto physical_base =
+            static_cast<std::uintptr_t>(entry) & kPage2MiBAddressMask;
+        return PageTranslation{
+            physical_base + (virtual_address & (kPage2MiB - 1)),
+            kPage2MiB,
+        };
+    }
+    table = static_cast<std::uintptr_t>(entry) & kTableAddressMask;
+
+    // PTE: ordinary 4 KiB mapping.
+    if (!read_table_entry(reader, table, table_index(virtual_address, 12), entry) ||
+        (entry & kPresent) == 0) {
+        return std::nullopt;
+    }
+
+    const auto physical_base =
+        static_cast<std::uintptr_t>(entry) & kPage4KiBAddressMask;
+    return PageTranslation{
+        physical_base + (virtual_address & (kPage4KiB - 1)),
+        kPage4KiB,
+    };
+}
 
 bool proc_read_dmap(
     DmapReadBackend& backend,

--- a/src/reconstruction/v1_stable_render_loop.cpp
+++ b/src/reconstruction/v1_stable_render_loop.cpp
@@ -1,0 +1,32 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#include "common_fps/v1_stable_render_loop.hpp"
+
+namespace common_fps::v1_stable {
+
+void RenderLoop::update(const HookState& state, RenderActions& actions) {
+    if (!label_ready_ && tick_ >= kLabelDelayTicks) {
+        label_ready_ = actions.create_fps_label();
+    }
+
+    if (label_ready_) {
+        RawSnapshot raw{};
+        if (state.snapshot_raw(raw) &&
+            raw.sequence != 0 &&
+            raw.sequence != last_raw_sequence_) {
+            actions.set_fps_text_raw(raw.text.data());
+            last_raw_sequence_ = raw.sequence;
+        }
+
+        TextSnapshot text{};
+        if (state.snapshot(text) &&
+            text.sequence != 0 &&
+            text.sequence != last_sequence_) {
+            actions.set_fps_text(text.text.data(), text.text2.data());
+            last_sequence_ = text.sequence;
+        }
+    }
+
+    ++tick_;
+}
+
+} // namespace common_fps::v1_stable

--- a/src/reconstruction/v1_stable_sampler.cpp
+++ b/src/reconstruction/v1_stable_sampler.cpp
@@ -1,0 +1,126 @@
+/* Common FPS for PS5 - GPL-3.0-or-later */
+#include "common_fps/v1_stable_sampler.hpp"
+
+#include "common_fps/constants.hpp"
+#include "common_fps/v1_stable_wire.hpp"
+
+#include <array>
+#include <cstring>
+
+namespace common_fps::v1_stable {
+
+Sampler::Sampler(Platform& platform)
+    : platform_(platform) {}
+
+bool Sampler::attach(ProcessId pid) {
+    reset();
+
+    const auto module = platform_.find_module(pid, "libSceVideoOut.sprx");
+    if (!module || module->base == 0)
+        return false;
+
+    pid_ = pid;
+    module_base_ = module->base;
+
+    if (!resolve_counter_address()) {
+        reset();
+        return false;
+    }
+    return true;
+}
+
+void Sampler::reset() {
+    pid_ = -1;
+    module_base_ = 0;
+    counter_address_ = 0;
+    have_baseline_ = false;
+    previous_counter_ = 0;
+    previous_time_us_ = 0;
+}
+
+bool Sampler::attached() const noexcept {
+    return pid_ >= 0 && counter_address_ != 0;
+}
+
+ProcessId Sampler::pid() const noexcept {
+    return pid_;
+}
+
+std::uintptr_t Sampler::counter_address() const noexcept {
+    return counter_address_;
+}
+
+bool Sampler::resolve_counter_address() {
+    constexpr std::size_t kTableSize =
+        kVideoOutProbeEntryCount * kVideoOutProbeEntrySize;
+    std::array<std::uint8_t, kTableSize> table{};
+
+    if (!platform_.read_memory(
+            pid_,
+            module_base_ + kVideoOutProbeTableOffset,
+            table.data(),
+            table.size())) {
+        return false;
+    }
+
+    for (std::size_t i = 0; i < kVideoOutProbeEntryCount; ++i) {
+        const auto* entry = table.data() + i * kVideoOutProbeEntrySize;
+        std::uint32_t enabled = 0;
+        std::uint64_t pointer = 0;
+        std::memcpy(&enabled, entry + 0x00, sizeof(enabled));
+        std::memcpy(&pointer, entry + 0x08, sizeof(pointer));
+
+        if (enabled == 0 || pointer == 0)
+            continue;
+
+        std::uint64_t root = 0;
+        if (!platform_.read_memory(
+                pid_, static_cast<std::uintptr_t>(pointer),
+                &root, sizeof(root))) {
+            return false;
+        }
+        if (root == 0)
+            return false;
+
+        counter_address_ =
+            static_cast<std::uintptr_t>(root) + kVideoOutCounterOffset;
+        return true;
+    }
+    return false;
+}
+
+std::optional<double> Sampler::sample() {
+    if (!attached())
+        return std::nullopt;
+
+    if (!platform_.process_alive(pid_)) {
+        reset();
+        return std::nullopt;
+    }
+
+    std::uint32_t current_counter = 0;
+    if (!platform_.read_memory(
+            pid_, counter_address_, &current_counter,
+            sizeof(current_counter))) {
+        reset();
+        return std::nullopt;
+    }
+
+    const auto now_us = platform_.monotonic_us();
+    if (!have_baseline_) {
+        have_baseline_ = true;
+        previous_counter_ = current_counter;
+        previous_time_us_ = now_us;
+        return std::nullopt;
+    }
+
+    const auto elapsed_us = now_us - previous_time_us_;
+    const auto value = calculate_fps(
+        previous_counter_, current_counter, elapsed_us);
+
+    previous_counter_ = current_counter;
+    previous_time_us_ = now_us;
+    return value;
+}
+
+} // namespace common_fps::v1_stable

--- a/tests/test_phu_donor_compare.py
+++ b/tests/test_phu_donor_compare.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from compare_phu_r11_donor import (
+    KNOWN_DONOR_SHA256,
+    KNOWN_STABLE_ELF_SHA256,
+    diff_runs,
+)
+
+
+def main() -> int:
+    assert diff_runs(b"abc", b"abc") == []
+    assert diff_runs(b"abc", b"axc") == [(1, 2)]
+    assert diff_runs(b"abcdef", b"abXXef") == [(2, 4)]
+    assert diff_runs(b"ab", b"abcd") == [(2, 4)]
+    assert len(KNOWN_DONOR_SHA256) == 64
+    assert len(KNOWN_STABLE_ELF_SHA256) == 64
+    print("PHU donor compare helper tests: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_v1_forensics.py
+++ b/tests/test_v1_forensics.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Small host tests for tools/analyze_v1_stable.py.
+
+The historical stable binary is intentionally not stored in the source tree,
+so CI tests only the format/parser helpers with synthetic data.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from tools.analyze_v1_stable import (  # noqa: E402
+    PLUGIN_HEADER_SIZE,
+    PLUGIN_MAGIC,
+    Symbol,
+    unique_file_symbols,
+    unwrap_plugin,
+)
+
+
+def test_plugin_wrapper() -> None:
+    header = b"etaHEN_PLUGIN\x00CFPS00020\x000.28\x00"
+    assert len(header) == PLUGIN_HEADER_SIZE
+    payload = b"\x7fELF" + b"test-payload"
+    elf, meta = unwrap_plugin(header + payload)
+    assert elf == payload
+    assert meta == {
+        "marker": "etaHEN_PLUGIN",
+        "title_id": "CFPS00020",
+        "version": "0.28",
+    }
+
+
+def test_plain_elf_passthrough() -> None:
+    payload = b"\x7fELF" + b"standalone"
+    elf, meta = unwrap_plugin(payload)
+    assert elf == payload
+    assert meta is None
+
+
+def test_file_symbol_dedup() -> None:
+    stt_file = 4
+    symbols = [
+        Symbol("main.cpp", stt_file, 1, 0, 0),
+        Symbol("main.cpp", stt_file, 1, 0, 0),
+        Symbol("elfldr.c", stt_file, 1, 0, 0),
+        Symbol("ordinary_function", 2, 1, 0, 0),
+    ]
+    assert unique_file_symbols(symbols) == ["main.cpp", "elfldr.c"]
+
+
+def test_reject_non_elf_plugin_payload() -> None:
+    header = PLUGIN_MAGIC + b"CFPS00020\x000.28\x00"
+    assert len(header) == PLUGIN_HEADER_SIZE
+    try:
+        unwrap_plugin(header + b"NOPE")
+    except ValueError as exc:
+        assert "not ELF" in str(exc)
+    else:
+        raise AssertionError("malformed plugin payload was accepted")
+
+
+def main() -> int:
+    test_plugin_wrapper()
+    test_plain_elf_passthrough()
+    test_file_symbol_dedup()
+    test_reject_non_elf_plugin_payload()
+    print("v1 forensic helper tests: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_v1_loader_contract.cpp
+++ b/tests/test_v1_loader_contract.cpp
@@ -1,0 +1,84 @@
+#include "v1_loader_contract.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+class MockBackend final : public common_fps::loader::Backend {
+public:
+    std::vector<std::string> calls;
+    bool scene_ok = true;
+    bool begin_ok = true;
+    bool image_ok = true;
+    bool args_ok = true;
+    bool exec_ok = true;
+    bool end_ok = true;
+
+    bool wait_for_shellui_scene() override {
+        calls.emplace_back("scene");
+        return scene_ok;
+    }
+    bool begin_loader_session() override {
+        calls.emplace_back("begin");
+        return begin_ok;
+    }
+    std::optional<common_fps::loader::LoadedImage>
+    load_renderer_image(const std::uint8_t*, std::size_t) override {
+        calls.emplace_back("image");
+        if (!image_ok)
+            return std::nullopt;
+        return common_fps::loader::LoadedImage{0x1234, 0x1000};
+    }
+    std::uintptr_t prepare_payload_args() override {
+        calls.emplace_back("args");
+        return args_ok ? 0x5678 : 0;
+    }
+    bool prepare_exec(std::uintptr_t entry,
+                      std::uintptr_t args) override {
+        calls.emplace_back("exec");
+        assert(entry == 0x1234);
+        assert(args == 0x5678);
+        return exec_ok;
+    }
+    bool end_loader_session() override {
+        calls.emplace_back("end");
+        return end_ok;
+    }
+};
+}
+
+int main() {
+    using common_fps::loader::install_renderer_v1_compatible;
+    const std::uint8_t dummy[] = {0x7f, 'E', 'L', 'F'};
+
+    MockBackend good;
+    assert(install_renderer_v1_compatible(good, dummy, sizeof(dummy)));
+    const std::vector<std::string> expected = {
+        "scene", "begin", "image", "args", "exec", "end"
+    };
+    assert(good.calls == expected);
+
+    // Payload args are created only after the image-load phase.
+    assert(good.calls[2] == "image");
+    assert(good.calls[3] == "args");
+
+    // Failures after begin still close the same loader session.
+    MockBackend image_fail;
+    image_fail.image_ok = false;
+    assert(!install_renderer_v1_compatible(
+        image_fail, dummy, sizeof(dummy)));
+    assert((image_fail.calls ==
+            std::vector<std::string>{"scene", "begin", "image", "end"}));
+
+    MockBackend args_fail;
+    args_fail.args_ok = false;
+    assert(!install_renderer_v1_compatible(
+        args_fail, dummy, sizeof(dummy)));
+    assert((args_fail.calls == std::vector<std::string>{
+        "scene", "begin", "image", "args", "end"
+    }));
+
+    return 0;
+}

--- a/tests/test_v1_parity.cpp
+++ b/tests/test_v1_parity.cpp
@@ -7,34 +7,38 @@
 
 #include "common_fps/config.hpp"
 #include "common_fps/types.hpp"
+#include "common_fps/v1_stable_wire.hpp"
 
 #include <cassert>
+#include <cmath>
+#include <cstdio>
 #include <iostream>
 #include <string>
-#include <type_traits>
 
 using namespace common_fps;
 
 int main() {
     const auto cfg = default_config();
 
-    // Stable v1.0.0 UI defaults.
+    // Stable v1.0.0 visible UI defaults.
     assert(cfg.corner == Corner::BottomLeft);
     assert(cfg.font_size == 26);
 
-    // Integer-only public transport.
-    OverlayFrame frame;
-    frame.loading = false;
-    frame.fps = 59;
-    static_assert(std::is_same_v<decltype(frame.fps), int>);
+    // Historical v1.0.0 did NOT send an integer on the wire. It retained
+    // tenth-FPS precision as a double and the ShellUI renderer formatted the
+    // visible value with %.0f.
+    v1_stable::FpsPacket packet{};
+    v1_stable::set_numeric(packet, 1, 59.6);
+    assert(std::fabs(packet.fps - 59.6) < 0.000001);
 
-    // Ensure our source model never needs a decimal string.
-    const std::string display =
-        std::string("FPS: ") + std::to_string(frame.fps);
+    char visible[32]{};
+    std::snprintf(visible, sizeof(visible), "%.0f", packet.fps);
+    assert(std::string(visible) == "60");
 
-    assert(display == "FPS: 59");
-    assert(display.find('.') == std::string::npos);
+    // Loading is a separate raw-text packet in the stable protocol.
+    v1_stable::set_loading(packet, 2);
+    assert(std::string(packet.raw) == "FPS\tloading\n");
 
-    std::cout << "v1.0.0 parity defaults: PASS\n";
+    std::cout << "v1.0.0 visible-display parity defaults: PASS\n";
     return 0;
 }

--- a/tests/test_v1_stable_controller.cpp
+++ b/tests/test_v1_stable_controller.cpp
@@ -1,0 +1,106 @@
+#include "common_fps/constants.hpp"
+#include "common_fps/v1_stable_controller.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+namespace {
+class MockPlatform final : public common_fps::Platform {
+public:
+    std::optional<common_fps::ProcessId> active_pid;
+    bool alive = false;
+    std::uintptr_t module_base = 0x10000000;
+    std::uintptr_t pointer = 0x20000000;
+    std::uintptr_t root = 0x30000000;
+    std::uint32_t counter = 1000;
+    std::uint64_t now_us = 1000000;
+
+    std::optional<common_fps::ProcessId> find_game_process() override {
+        return active_pid;
+    }
+    bool process_alive(common_fps::ProcessId pid) override {
+        return alive && active_pid && *active_pid == pid;
+    }
+    std::optional<common_fps::ModuleInfo>
+    find_module(common_fps::ProcessId pid, const char* name) override {
+        if (!process_alive(pid)) return std::nullopt;
+        return common_fps::ModuleInfo{module_base, name};
+    }
+    bool read_memory(common_fps::ProcessId pid, std::uintptr_t addr,
+                     void* out, std::size_t size) override {
+        using namespace common_fps;
+        if (!process_alive(pid)) return false;
+        if (addr == module_base + kVideoOutProbeTableOffset) {
+            const std::size_t n =
+                kVideoOutProbeEntryCount * kVideoOutProbeEntrySize;
+            assert(size == n);
+            std::vector<std::uint8_t> table(n, 0);
+            const std::uint32_t enabled = 1;
+            std::memcpy(table.data(), &enabled, 4);
+            std::memcpy(table.data() + 8, &pointer, 8);
+            std::memcpy(out, table.data(), n);
+            return true;
+        }
+        if (addr == pointer) {
+            std::memcpy(out, &root, sizeof(root));
+            return true;
+        }
+        if (addr == root + kVideoOutCounterOffset) {
+            std::memcpy(out, &counter, sizeof(counter));
+            return true;
+        }
+        return false;
+    }
+    std::uint64_t monotonic_us() override { return now_us; }
+    void sleep_ms(unsigned ms) override { now_us += ms * 1000ull; }
+};
+
+class Sink final : public common_fps::v1_stable::PacketSink {
+public:
+    std::vector<common_fps::v1_stable::FpsPacket> packets;
+    bool send(const common_fps::v1_stable::FpsPacket& p) override {
+        packets.push_back(p);
+        return true;
+    }
+};
+}
+
+int main() {
+    using namespace common_fps::v1_stable;
+
+    MockPlatform p;
+    Sink sink;
+    Controller controller(p, sink);
+
+    // No game: stable loading packet.
+    controller.tick();
+    assert(sink.packets.size() == 1);
+    assert(std::string(sink.packets.back().raw) == "FPS\tloading\n");
+    assert(sink.packets.back().sequence == 1);
+
+    // Game appears: first sample establishes baseline and remains loading.
+    p.active_pid = 100;
+    p.alive = true;
+    controller.tick();
+    assert(controller.attached());
+    assert(sink.packets.back().sequence == 2);
+    assert(std::string(sink.packets.back().raw) == "FPS\tloading\n");
+
+    // 60 counter increments over the one-second controller interval.
+    p.counter += 60;
+    controller.tick();
+    assert(sink.packets.back().sequence == 3);
+    assert(sink.packets.back().raw[0] == '\0');
+    assert(std::fabs(sink.packets.back().fps - 60.0) < 0.000001);
+
+    // Exit resets sampling; next iteration returns to loading.
+    p.alive = false;
+    controller.tick();
+    assert(std::string(sink.packets.back().raw) == "FPS\tloading\n");
+    assert(!controller.attached());
+
+    return 0;
+}

--- a/tests/test_v1_stable_hook_state.cpp
+++ b/tests/test_v1_stable_hook_state.cpp
@@ -1,0 +1,44 @@
+#include "common_fps/v1_stable_hook_state.hpp"
+
+#include <cassert>
+#include <cstring>
+#include <string>
+
+int main() {
+    using namespace common_fps::v1_stable;
+
+    HookState state;
+    assert(state.sequence() == 0);
+    assert(state.raw_sequence() == 0);
+
+    state.publish("FPS:", "60");
+    assert(state.sequence() == 2);
+
+    TextSnapshot text{};
+    assert(state.snapshot(text));
+    assert(text.sequence == 2);
+    assert(std::strcmp(text.text.data(), "FPS:") == 0);
+    assert(std::strcmp(text.text2.data(), "60") == 0);
+
+    state.publish_raw("FPS: loading\n");
+    assert(state.raw_sequence() == 2);
+
+    RawSnapshot raw{};
+    assert(state.snapshot_raw(raw));
+    assert(raw.sequence == 2);
+    assert(std::strcmp(raw.text.data(), "FPS: loading\n") == 0);
+
+    // Stable buffers reserve one byte for the trailing NUL.
+    std::string long_text(kHookTextCapacity + 100, 'A');
+    state.publish_raw(long_text.c_str());
+    assert(state.snapshot_raw(raw));
+    assert(std::strlen(raw.text.data()) == kHookTextCapacity - 1);
+    assert(raw.text[kHookTextCapacity - 1] == '\0');
+
+    // Null publishes are ignored, matching the donor guards.
+    const auto seq_before = state.sequence();
+    state.publish(nullptr, "x");
+    assert(state.sequence() == seq_before);
+
+    return 0;
+}

--- a/tests/test_v1_stable_memory.cpp
+++ b/tests/test_v1_stable_memory.cpp
@@ -1,0 +1,115 @@
+#include "common_fps/v1_stable_memory.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+namespace {
+
+class FakeDmap final : public common_fps::v1_stable::DmapReadBackend {
+public:
+    struct Call {
+        std::uintptr_t virtual_address;
+        std::uintptr_t physical_address;
+        std::size_t size;
+    };
+
+    std::vector<Call> calls;
+    bool fail_translate = false;
+    bool fail_copy = false;
+    std::size_t page_size = 0x1000;
+
+    std::optional<common_fps::v1_stable::PageTranslation>
+    translate(common_fps::ProcessId,
+              std::uintptr_t virtual_address) override {
+        if (fail_translate)
+            return std::nullopt;
+
+        // Keep a simple 1:1 virtual->physical mapping for the host model.
+        return common_fps::v1_stable::PageTranslation{
+            virtual_address,
+            page_size,
+        };
+    }
+
+    bool copy_physical(std::uintptr_t physical_address,
+                       void* output,
+                       std::size_t size) override {
+        if (fail_copy)
+            return false;
+
+        auto* bytes = static_cast<std::uint8_t*>(output);
+        for (std::size_t i = 0; i < size; ++i)
+            bytes[i] = static_cast<std::uint8_t>((physical_address + i) & 0xff);
+
+        calls.push_back(Call{physical_address, physical_address, size});
+        return true;
+    }
+};
+
+} // namespace
+
+int main() {
+    using common_fps::v1_stable::proc_read_dmap;
+
+    // Stable prw::proc_read treats zero-length reads as success.
+    {
+        FakeDmap backend;
+        assert(proc_read_dmap(backend, 42, 0x1234, nullptr, 0));
+        assert(backend.calls.empty());
+    }
+
+    // One read fully contained in one page -> one physical copy.
+    {
+        FakeDmap backend;
+        std::uint8_t output[16]{};
+        assert(proc_read_dmap(backend, 42, 0x1200, output, sizeof(output)));
+        assert(backend.calls.size() == 1);
+        assert(backend.calls[0].physical_address == 0x1200);
+        assert(backend.calls[0].size == sizeof(output));
+        assert(output[0] == 0x00);
+        assert(output[1] == 0x01);
+    }
+
+    // Crossing a 4 KiB mapping must split exactly at the page boundary.
+    {
+        FakeDmap backend;
+        std::uint8_t output[32]{};
+        assert(proc_read_dmap(backend, 42, 0x0ff8, output, sizeof(output)));
+        assert(backend.calls.size() == 2);
+        assert(backend.calls[0].physical_address == 0x0ff8);
+        assert(backend.calls[0].size == 8);
+        assert(backend.calls[1].physical_address == 0x1000);
+        assert(backend.calls[1].size == 24);
+    }
+
+    // The same algorithm must honor a large-page size returned by translate().
+    {
+        FakeDmap backend;
+        backend.page_size = 0x200000;
+        std::uint8_t output[32]{};
+        assert(proc_read_dmap(
+            backend, 42, 0x1ffff8, output, sizeof(output)));
+        assert(backend.calls.size() == 2);
+        assert(backend.calls[0].size == 8);
+        assert(backend.calls[1].size == 24);
+    }
+
+    {
+        FakeDmap backend;
+        backend.fail_translate = true;
+        std::uint8_t output[4]{};
+        assert(!proc_read_dmap(backend, 42, 0x1000, output, sizeof(output)));
+    }
+
+    {
+        FakeDmap backend;
+        backend.fail_copy = true;
+        std::uint8_t output[4]{};
+        assert(!proc_read_dmap(backend, 42, 0x1000, output, sizeof(output)));
+    }
+
+    return 0;
+}

--- a/tests/test_v1_stable_memory.cpp
+++ b/tests/test_v1_stable_memory.cpp
@@ -2,16 +2,37 @@
 
 #include <cassert>
 #include <cstdint>
-#include <cstring>
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 namespace {
 
+constexpr std::uintptr_t idx(std::uintptr_t va, unsigned shift) {
+    return (va >> shift) & 0x1ffull;
+}
+
+class FakePageTables final : public common_fps::v1_stable::PhysicalEntryReader {
+public:
+    std::unordered_map<std::uintptr_t, std::uint64_t> entries;
+
+    bool read_entry(std::uintptr_t physical_address,
+                    std::uint64_t& value) override {
+        const auto it = entries.find(physical_address);
+        if (it == entries.end())
+            return false;
+        value = it->second;
+        return true;
+    }
+
+    void set(std::uintptr_t table, std::uintptr_t index, std::uint64_t value) {
+        entries[table + index * 8] = value;
+    }
+};
+
 class FakeDmap final : public common_fps::v1_stable::DmapReadBackend {
 public:
     struct Call {
-        std::uintptr_t virtual_address;
         std::uintptr_t physical_address;
         std::size_t size;
     };
@@ -27,7 +48,7 @@ public:
         if (fail_translate)
             return std::nullopt;
 
-        // Keep a simple 1:1 virtual->physical mapping for the host model.
+        // Keep a simple 1:1 virtual->physical mapping for the chunking model.
         return common_fps::v1_stable::PageTranslation{
             virtual_address,
             page_size,
@@ -44,7 +65,7 @@ public:
         for (std::size_t i = 0; i < size; ++i)
             bytes[i] = static_cast<std::uint8_t>((physical_address + i) & 0xff);
 
-        calls.push_back(Call{physical_address, physical_address, size});
+        calls.push_back(Call{physical_address, size});
         return true;
     }
 };
@@ -53,6 +74,72 @@ public:
 
 int main() {
     using common_fps::v1_stable::proc_read_dmap;
+    using common_fps::v1_stable::translate_x86_64;
+
+    // Ordinary 4 KiB page walk.
+    {
+        constexpr std::uintptr_t va = 0x0000000123456789ull;
+        constexpr std::uintptr_t cr3 = 0x1000;
+        constexpr std::uintptr_t pdpt = 0x2000;
+        constexpr std::uintptr_t pd = 0x3000;
+        constexpr std::uintptr_t pt = 0x4000;
+        constexpr std::uintptr_t frame = 0x0000000abcde0000ull;
+
+        FakePageTables tables;
+        tables.set(cr3, idx(va, 39), pdpt | 0x1);
+        tables.set(pdpt, idx(va, 30), pd | 0x1);
+        tables.set(pd, idx(va, 21), pt | 0x1);
+        tables.set(pt, idx(va, 12), frame | 0x1);
+
+        const auto translated = translate_x86_64(tables, cr3 | 0x123, va);
+        assert(translated.has_value());
+        assert(translated->page_size == 0x1000);
+        assert(translated->physical == frame + (va & 0xfff));
+    }
+
+    // 2 MiB PDE large page.
+    {
+        constexpr std::uintptr_t va = 0x00000000456789abull;
+        constexpr std::uintptr_t cr3 = 0x5000;
+        constexpr std::uintptr_t pdpt = 0x6000;
+        constexpr std::uintptr_t pd = 0x7000;
+        constexpr std::uintptr_t frame = 0x0000000080000000ull;
+
+        FakePageTables tables;
+        tables.set(cr3, idx(va, 39), pdpt | 0x1);
+        tables.set(pdpt, idx(va, 30), pd | 0x1);
+        tables.set(pd, idx(va, 21), frame | 0x81); // present + PS
+
+        const auto translated = translate_x86_64(tables, cr3, va);
+        assert(translated.has_value());
+        assert(translated->page_size == 0x200000);
+        assert(translated->physical == frame + (va & 0x1fffff));
+    }
+
+    // 1 GiB PDPTE large page.
+    {
+        constexpr std::uintptr_t va = 0x0000000187654321ull;
+        constexpr std::uintptr_t cr3 = 0x8000;
+        constexpr std::uintptr_t pdpt = 0x9000;
+        constexpr std::uintptr_t frame = 0x00000000c0000000ull;
+
+        FakePageTables tables;
+        tables.set(cr3, idx(va, 39), pdpt | 0x1);
+        tables.set(pdpt, idx(va, 30), frame | 0x81); // present + PS
+
+        const auto translated = translate_x86_64(tables, cr3, va);
+        assert(translated.has_value());
+        assert(translated->page_size == 0x40000000ull);
+        assert(translated->physical == frame + (va & 0x3fffffffull));
+    }
+
+    // Missing/not-present entry is a clean translation failure.
+    {
+        constexpr std::uintptr_t va = 0x12345000;
+        FakePageTables tables;
+        tables.set(0x1000, idx(va, 39), 0x2000); // not present
+        assert(!translate_x86_64(tables, 0x1000, va).has_value());
+    }
 
     // Stable prw::proc_read treats zero-length reads as success.
     {
@@ -85,7 +172,7 @@ int main() {
         assert(backend.calls[1].size == 24);
     }
 
-    // The same algorithm must honor a large-page size returned by translate().
+    // The same chunker honors a large-page size returned by translate().
     {
         FakeDmap backend;
         backend.page_size = 0x200000;

--- a/tests/test_v1_stable_overlay.cpp
+++ b/tests/test_v1_stable_overlay.cpp
@@ -1,0 +1,35 @@
+#include "common_fps/v1_stable_overlay.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+int main() {
+    using namespace common_fps::v1_stable;
+
+    assert(std::string(kLabelText) == "FPS:");
+    assert(std::string(kLoadingVisibleText) == "FPS: loading");
+    assert(std::string(kNumericFormat) == "%.0f");
+    assert(kFontSize == 26);
+    assert(kRawCursorX == 10.0f);
+    assert(kRawCursorY == 1038.0f);
+
+    assert(kLabelColor.r == 0xB3);
+    assert(kLabelColor.g == 0x66);
+    assert(kLabelColor.b == 0xFF);
+    assert(kLabelColor.a == 0xFF);
+
+    assert(kValueColor.r == 0xFF);
+    assert(kValueColor.g == 0xFF);
+    assert(kValueColor.b == 0xFF);
+    assert(kValueColor.a == 0xFF);
+
+    assert(std::fabs(initial_cursor_y(1920.0f) - 1070.0f) < 0.001f);
+
+    char value[32]{};
+    std::snprintf(value, sizeof(value), kNumericFormat, 59.6);
+    assert(std::string(value) == "60");
+
+    return 0;
+}

--- a/tests/test_v1_stable_render_loop.cpp
+++ b/tests/test_v1_stable_render_loop.cpp
@@ -1,0 +1,74 @@
+#include "common_fps/v1_stable_render_loop.hpp"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+namespace {
+class MockActions final : public common_fps::v1_stable::RenderActions {
+public:
+    bool create_result = true;
+    int create_calls = 0;
+    std::vector<std::string> raw_values;
+    std::vector<std::string> split_values;
+
+    bool create_fps_label() override {
+        ++create_calls;
+        return create_result;
+    }
+    void set_fps_text_raw(const char* value) override {
+        raw_values.emplace_back(value ? value : "");
+    }
+    void set_fps_text(const char* a, const char* b) override {
+        split_values.emplace_back(
+            std::string(a ? a : "") + "|" + (b ? b : ""));
+    }
+};
+}
+
+int main() {
+    using namespace common_fps::v1_stable;
+
+    HookState state;
+    RenderLoop loop;
+    MockActions actions;
+    state.publish_raw("FPS: loading\n");
+    state.publish("FPS:", "60");
+
+    for (int i = 0; i < 30; ++i)
+        loop.update(state, actions);
+    assert(actions.create_calls == 0);
+    assert(!loop.label_ready());
+
+    loop.update(state, actions);
+    assert(actions.create_calls == 1);
+    assert(loop.label_ready());
+    assert(actions.raw_values.size() == 1);
+    assert(actions.raw_values.back() == "FPS: loading\n");
+    assert(actions.split_values.size() == 1);
+    assert(actions.split_values.back() == "FPS:|60");
+
+    loop.update(state, actions);
+    assert(actions.raw_values.size() == 1);
+    assert(actions.split_values.size() == 1);
+
+    state.publish("FPS:", "59");
+    loop.update(state, actions);
+    assert(actions.split_values.size() == 2);
+    assert(actions.split_values.back() == "FPS:|59");
+
+    RenderLoop retry_loop;
+    MockActions retry;
+    retry.create_result = false;
+    for (int i = 0; i < 30; ++i)
+        retry_loop.update(state, retry);
+    retry_loop.update(state, retry);
+    assert(retry.create_calls == 1);
+    assert(!retry_loop.label_ready());
+
+    retry.create_result = true;
+    retry_loop.update(state, retry);
+    assert(retry.create_calls == 2);
+    assert(retry_loop.label_ready());
+    return 0;
+}

--- a/tests/test_v1_stable_sampler.cpp
+++ b/tests/test_v1_stable_sampler.cpp
@@ -1,0 +1,99 @@
+#include "common_fps/constants.hpp"
+#include "common_fps/v1_stable_sampler.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+namespace {
+class MockPlatform final : public common_fps::Platform {
+public:
+    std::optional<common_fps::ProcessId> active_pid;
+    bool alive = false;
+    std::uintptr_t module_base = 0x10000000;
+    std::uintptr_t record_pointer = 0x20000000;
+    std::uintptr_t counter_root = 0x30000000;
+    std::uint32_t counter = 1000;
+    std::uint64_t now_us = 1000000;
+
+    std::optional<common_fps::ProcessId> find_game_process() override {
+        return active_pid;
+    }
+    bool process_alive(common_fps::ProcessId pid) override {
+        return alive && active_pid && *active_pid == pid;
+    }
+    std::optional<common_fps::ModuleInfo>
+    find_module(common_fps::ProcessId pid, const char* name) override {
+        if (!process_alive(pid))
+            return std::nullopt;
+        return common_fps::ModuleInfo{module_base, name};
+    }
+    bool read_memory(common_fps::ProcessId pid,
+                     std::uintptr_t address,
+                     void* out,
+                     std::size_t size) override {
+        using namespace common_fps;
+        if (!process_alive(pid))
+            return false;
+
+        if (address == module_base + kVideoOutProbeTableOffset) {
+            const std::size_t expected =
+                kVideoOutProbeEntryCount * kVideoOutProbeEntrySize;
+            assert(size == expected);
+            std::vector<std::uint8_t> table(expected, 0);
+            const std::uint32_t enabled = 1;
+            std::memcpy(table.data(), &enabled, sizeof(enabled));
+            std::memcpy(table.data() + 8, &record_pointer,
+                        sizeof(record_pointer));
+            std::memcpy(out, table.data(), expected);
+            return true;
+        }
+        if (address == record_pointer) {
+            std::memcpy(out, &counter_root, sizeof(counter_root));
+            return true;
+        }
+        if (address == counter_root + kVideoOutCounterOffset) {
+            std::memcpy(out, &counter, sizeof(counter));
+            return true;
+        }
+        return false;
+    }
+    std::uint64_t monotonic_us() override { return now_us; }
+    void sleep_ms(unsigned ms) override { now_us += ms * 1000ull; }
+
+    void advance(std::uint32_t frames, std::uint64_t us) {
+        counter += frames;
+        now_us += us;
+    }
+};
+}
+
+int main() {
+    using common_fps::v1_stable::Sampler;
+
+    MockPlatform p;
+    p.active_pid = 100;
+    p.alive = true;
+
+    Sampler sampler(p);
+    assert(sampler.attach(100));
+    assert(sampler.attached());
+
+    // First reading only establishes the stable baseline.
+    assert(!sampler.sample().has_value());
+
+    // Preserve tenth-FPS precision exactly as v1.0.0 did on its wire.
+    p.advance(596, 10000000);
+    const auto value = sampler.sample();
+    assert(value.has_value());
+    assert(std::fabs(*value - 59.6) < 0.000001);
+
+    // Process exit resets attachment state.
+    p.alive = false;
+    assert(!sampler.sample().has_value());
+    assert(!sampler.attached());
+
+    return 0;
+}

--- a/tests/test_v1_stable_wire.cpp
+++ b/tests/test_v1_stable_wire.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <cstring>
 
 int main() {
@@ -11,6 +12,8 @@ int main() {
     static_assert(kWireVersion == 1);
     static_assert(kWirePort == 55541);
     static_assert(sizeof(FpsPacket) == 0x420);
+    static_assert(offsetof(FpsPacket, last_ns) == 0x18);
+    static_assert(offsetof(FpsPacket, text) == 0x20);
 
     FpsPacket packet{};
     set_loading(packet, 7);
@@ -18,12 +21,14 @@ int main() {
     assert(packet.version == 1);
     assert(packet.sequence == 7);
     assert(packet.fps == 0.0);
-    assert(std::strcmp(packet.raw, "FPS\tloading\n") == 0);
+    assert(packet.last_ns == 0);
+    assert(std::strcmp(packet.text, "FPS\tloading\n") == 0);
 
     set_numeric(packet, 8, 59.9);
     assert(packet.sequence == 8);
     assert(std::fabs(packet.fps - 59.9) < 0.000001);
-    assert(packet.raw[0] == '\0');
+    assert(packet.last_ns == 0);
+    assert(packet.text[0] == '\0');
 
     const auto fps60 = calculate_fps(1000, 1060, 1000000);
     assert(fps60.has_value());

--- a/tests/test_v1_stable_wire.cpp
+++ b/tests/test_v1_stable_wire.cpp
@@ -1,0 +1,48 @@
+#include "common_fps/v1_stable_wire.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+
+int main() {
+    using namespace common_fps::v1_stable;
+
+    static_assert(kWireMagic == 0x46554850u);
+    static_assert(kWireVersion == 1);
+    static_assert(kWirePort == 55541);
+    static_assert(sizeof(FpsPacket) == 0x420);
+
+    FpsPacket packet{};
+    set_loading(packet, 7);
+    assert(packet.magic == kWireMagic);
+    assert(packet.version == 1);
+    assert(packet.sequence == 7);
+    assert(packet.fps == 0.0);
+    assert(std::strcmp(packet.raw, "FPS\tloading\n") == 0);
+
+    set_numeric(packet, 8, 59.9);
+    assert(packet.sequence == 8);
+    assert(std::fabs(packet.fps - 59.9) < 0.000001);
+    assert(packet.raw[0] == '\0');
+
+    const auto fps60 = calculate_fps(1000, 1060, 1000000);
+    assert(fps60.has_value());
+    assert(std::fabs(*fps60 - 60.0) < 0.000001);
+
+    const auto fps2999 = calculate_fps(0, 2999, 10000000);
+    assert(fps2999.has_value());
+    assert(std::fabs(*fps2999 - 299.9) < 0.000001);
+
+    const auto fpsTooHigh = calculate_fps(0, 301, 1000000);
+    assert(!fpsTooHigh.has_value());
+
+    const auto noTime = calculate_fps(0, 60, 0);
+    assert(!noTime.has_value());
+
+    // The stable code subtracts uint32_t counters, so wrap-around is natural.
+    const auto wrapped = calculate_fps(0xfffffff0u, 0x0000000eu, 1000000);
+    assert(wrapped.has_value());
+    assert(std::fabs(*wrapped - 30.0) < 0.000001);
+
+    return 0;
+}

--- a/tools/analyze_v1_stable.py
+++ b/tools/analyze_v1_stable.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Forensic verifier for the historical Common FPS v1.0.0 stable binary.
+
+This tool does not patch or execute the payload. It validates the known stable
+etaHEN wrapper / ELF hashes, inventories ELF FILE symbols, and extracts the
+embedded ShellUI renderer by symbol boundaries when present.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+PLUGIN_MAGIC = b"etaHEN_PLUGIN\x00"
+PLUGIN_HEADER_SIZE = 29
+KNOWN_PLUGIN_SHA256 = "f1240511bfe3cb17a3db6f4d099cf3cd69be678d10901425a7b33911265195e1"
+KNOWN_ELF_SHA256 = "6a66da88a99fa8757bf5c649e388d777a10768cd444d9f4cf82649e4592e292c"
+KNOWN_RENDERER_SHA256 = "3640cbcaf907bc900e257503b3c8922fdbc129c492a76a2348fd75c84f68b91c"
+RENDERER_START = "_binary_libphu_overlay_so_start"
+RENDERER_END = "_binary_libphu_overlay_so_end"
+HIGH_VALUE_SYMBOLS = (
+    "main",
+    "probe_main_entry",
+    "inject_main_entry",
+    "inject_elf",
+    "elfldr_load",
+    "elfldr_payload_args",
+    "_ZN8Hijacker8getEbootEv",
+    "_ZN12videoout_ioctl4initEv",
+    "_ZN12videoout_ioctl6sampleEv",
+    "_ZN13phu_recovery18check_and_reinjectEv",
+    RENDERER_START,
+    RENDERER_END,
+)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class Section:
+    index: int
+    name: str
+    sh_type: int
+    flags: int
+    addr: int
+    offset: int
+    size: int
+    link: int
+    entsize: int
+
+
+@dataclass(frozen=True)
+class Symbol:
+    name: str
+    info: int
+    shndx: int
+    value: int
+    size: int
+
+    @property
+    def st_type(self) -> int:
+        return self.info & 0x0F
+
+
+class Elf64:
+    def __init__(self, data: bytes):
+        self.data = data
+        if len(data) < 0x40 or data[:4] != b"\x7fELF":
+            raise ValueError("not an ELF file")
+        if data[4] != 2 or data[5] != 1:
+            raise ValueError("expected ELF64 little-endian")
+        self.e_shoff = struct.unpack_from("<Q", data, 0x28)[0]
+        self.e_shentsize = struct.unpack_from("<H", data, 0x3A)[0]
+        self.e_shnum = struct.unpack_from("<H", data, 0x3C)[0]
+        self.e_shstrndx = struct.unpack_from("<H", data, 0x3E)[0]
+        if self.e_shentsize < 64:
+            raise ValueError("unexpected section header size")
+        self.sections = self._parse_sections()
+        self.symbols = self._parse_symbols()
+
+    def _raw_shdr(self, index: int):
+        off = self.e_shoff + index * self.e_shentsize
+        if off + 64 > len(self.data):
+            raise ValueError("section table extends past end of file")
+        return struct.unpack_from("<IIQQQQIIQQ", self.data, off)
+
+    def _parse_sections(self) -> list[Section]:
+        raw = [self._raw_shdr(i) for i in range(self.e_shnum)]
+        if self.e_shstrndx >= len(raw):
+            raise ValueError("invalid shstrndx")
+        names_hdr = raw[self.e_shstrndx]
+        names = self.data[names_hdr[4]: names_hdr[4] + names_hdr[5]]
+
+        def cstr(blob: bytes, off: int) -> str:
+            if off >= len(blob):
+                return ""
+            end = blob.find(b"\x00", off)
+            if end < 0:
+                end = len(blob)
+            return blob[off:end].decode("utf-8", "replace")
+
+        out: list[Section] = []
+        for i, h in enumerate(raw):
+            out.append(Section(
+                index=i,
+                name=cstr(names, h[0]),
+                sh_type=h[1],
+                flags=h[2],
+                addr=h[3],
+                offset=h[4],
+                size=h[5],
+                link=h[6],
+                entsize=h[9],
+            ))
+        return out
+
+    def _parse_symbols(self) -> list[Symbol]:
+        result: list[Symbol] = []
+        for sec in self.sections:
+            if sec.sh_type not in (2, 11):  # SHT_SYMTAB / SHT_DYNSYM
+                continue
+            if not sec.entsize or sec.link >= len(self.sections):
+                continue
+            strings_sec = self.sections[sec.link]
+            strings = self.data[strings_sec.offset: strings_sec.offset + strings_sec.size]
+            count = sec.size // sec.entsize
+            for i in range(count):
+                off = sec.offset + i * sec.entsize
+                if off + 24 > len(self.data):
+                    break
+                st_name, st_info, _st_other, st_shndx, st_value, st_size = struct.unpack_from(
+                    "<IBBHQQ", self.data, off
+                )
+                if st_name >= len(strings):
+                    name = ""
+                else:
+                    end = strings.find(b"\x00", st_name)
+                    if end < 0:
+                        end = len(strings)
+                    name = strings[st_name:end].decode("utf-8", "replace")
+                result.append(Symbol(name, st_info, st_shndx, st_value, st_size))
+        return result
+
+    def symbols_named(self, name: str) -> list[Symbol]:
+        return [s for s in self.symbols if s.name == name]
+
+    def va_to_file_offset(self, value: int) -> int:
+        # Prefer a physical section rather than SHT_NOBITS storage.
+        for sec in self.sections:
+            if sec.sh_type == 8:  # SHT_NOBITS
+                continue
+            if sec.size and sec.addr <= value < sec.addr + sec.size:
+                delta = value - sec.addr
+                file_off = sec.offset + delta
+                if file_off < len(self.data):
+                    return file_off
+        raise ValueError(f"cannot map VA 0x{value:x} to file offset")
+
+
+def unwrap_plugin(data: bytes) -> tuple[bytes, dict[str, str] | None]:
+    if not data.startswith(PLUGIN_MAGIC):
+        return data, None
+    if len(data) < PLUGIN_HEADER_SIZE + 4:
+        raise ValueError("etaHEN plugin is truncated")
+    header = data[:PLUGIN_HEADER_SIZE]
+    parts = header.split(b"\x00")
+    if len(parts) < 4:
+        raise ValueError("etaHEN plugin header is malformed")
+    meta = {
+        "marker": parts[0].decode("ascii", "replace"),
+        "title_id": parts[1].decode("ascii", "replace"),
+        "version": parts[2].decode("ascii", "replace"),
+    }
+    elf = data[PLUGIN_HEADER_SIZE:]
+    if not elf.startswith(b"\x7fELF"):
+        raise ValueError("etaHEN plugin payload is not ELF")
+    return elf, meta
+
+
+def unique_file_symbols(symbols: Iterable[Symbol]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for symbol in symbols:
+        if symbol.st_type == 4 and symbol.name and symbol.name not in seen:  # STT_FILE
+            seen.add(symbol.name)
+            out.append(symbol.name)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("input", type=Path, help="historical v1.0.0 .plugin or payload .elf")
+    ap.add_argument(
+        "--extract-renderer",
+        type=Path,
+        default=None,
+        help="write embedded libphu_overlay.so to this path",
+    )
+    ap.add_argument("--json", type=Path, default=None, help="write machine-readable report")
+    args = ap.parse_args()
+
+    raw = args.input.read_bytes()
+    raw_hash = sha256_bytes(raw)
+    elf_data, plugin_meta = unwrap_plugin(raw)
+    elf_hash = sha256_bytes(elf_data)
+    elf = Elf64(elf_data)
+
+    stable_plugin_match = raw_hash == KNOWN_PLUGIN_SHA256 if plugin_meta else None
+    stable_elf_match = elf_hash == KNOWN_ELF_SHA256
+
+    file_units = unique_file_symbols(elf.symbols)
+    symbol_map: dict[str, list[dict[str, int]]] = {}
+    for name in HIGH_VALUE_SYMBOLS:
+        hits = elf.symbols_named(name)
+        if hits:
+            symbol_map[name] = [
+                {"value": symbol.value, "size": symbol.size, "shndx": symbol.shndx}
+                for symbol in hits
+            ]
+
+    renderer_info = None
+    start_hits = elf.symbols_named(RENDERER_START)
+    end_hits = elf.symbols_named(RENDERER_END)
+    if start_hits and end_hits:
+        start_va = start_hits[0].value
+        end_va = end_hits[0].value
+        if end_va <= start_va:
+            raise ValueError("renderer end precedes start")
+        start_off = elf.va_to_file_offset(start_va)
+        end_off = elf.va_to_file_offset(end_va - 1) + 1
+        renderer = elf_data[start_off:end_off]
+        renderer_hash = sha256_bytes(renderer)
+        renderer_info = {
+            "start_va": start_va,
+            "end_va": end_va,
+            "size": len(renderer),
+            "sha256": renderer_hash,
+            "known_stable_match": renderer_hash == KNOWN_RENDERER_SHA256,
+        }
+        if args.extract_renderer:
+            args.extract_renderer.parent.mkdir(parents=True, exist_ok=True)
+            args.extract_renderer.write_bytes(renderer)
+
+    report = {
+        "input": str(args.input),
+        "input_size": len(raw),
+        "input_sha256": raw_hash,
+        "plugin": plugin_meta,
+        "known_plugin_match": stable_plugin_match,
+        "payload_elf_size": len(elf_data),
+        "payload_elf_sha256": elf_hash,
+        "known_payload_match": stable_elf_match,
+        "file_symbols": file_units,
+        "high_value_symbols": symbol_map,
+        "embedded_renderer": renderer_info,
+    }
+
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    if plugin_meta and not stable_plugin_match:
+        print("WARNING: plugin hash does not match historical v1.0.0")
+    if not stable_elf_match:
+        print("WARNING: payload ELF hash does not match historical v1.0.0")
+    if renderer_info and not renderer_info["known_stable_match"]:
+        print("WARNING: embedded renderer hash does not match recovered stable renderer")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_v1_source_gate.py
+++ b/tools/check_v1_source_gate.py
@@ -17,6 +17,14 @@ checks = [
      "include/common_fps/v1_stable_wire.hpp",
      "sizeof(FpsPacket) == 0x420"),
 
+    ("DWARF last_ns field",
+     "include/common_fps/v1_stable_wire.hpp",
+     "last_ns"),
+
+    ("DWARF text field",
+     "include/common_fps/v1_stable_wire.hpp",
+     "char text[kTextCapacity]"),
+
     ("stable loading payload",
      "include/common_fps/v1_stable_wire.hpp",
      '"FPS\\tloading\\n"'),
@@ -28,6 +36,14 @@ checks = [
     ("stable VideoOut sampler",
      "src/reconstruction/v1_stable_sampler.cpp",
      '"libSceVideoOut.sprx"'),
+
+    ("stable DMAP read model",
+     "src/reconstruction/v1_stable_memory.cpp",
+     "proc_read_dmap"),
+
+    ("stable page-boundary chunking",
+     "src/reconstruction/v1_stable_memory.cpp",
+     "page_size - offset_in_page"),
 
     ("stable odd/even publisher",
      "src/reconstruction/v1_stable_hook_state.cpp",
@@ -52,6 +68,10 @@ checks = [
     ("single loader session",
      "docs/V1_0_0_PARITY_CONTRACT.md",
      "Do not break one loader session"),
+
+    ("DMAP parity documented",
+     "docs/V1_0_0_RECONSTRUCTED_SOURCE_MAP.md",
+     "prw::proc_read"),
 
     ("font 26",
      "include/common_fps/constants.hpp",
@@ -97,6 +117,19 @@ print(
     "no extra post-load continue_target"
 )
 failed |= not no_extra_continue
+
+# Stable v1.0.0 sampled game VideoOut through PHU's DMAP proc_read path.
+# Per-read ptrace was introduced only by the later clean rewrite. Keep ptrace
+# primitives completely out of the reconstructed parity core.
+reconstruction_dir = root / "src" / "reconstruction"
+reconstruction_text = "\n".join(
+    path.read_text(encoding="utf-8")
+    for path in reconstruction_dir.glob("*.cpp")
+)
+for forbidden in ("pt_attach(", "pt_copyout(", "pt_detach("):
+    ok = forbidden not in reconstruction_text
+    print(f"{'PASS' if ok else 'FAIL'}  no parity per-read ptrace: {forbidden}")
+    failed |= not ok
 
 if failed:
     sys.exit(1)

--- a/tools/check_v1_source_gate.py
+++ b/tools/check_v1_source_gate.py
@@ -37,6 +37,14 @@ checks = [
      "src/reconstruction/v1_stable_sampler.cpp",
      '"libSceVideoOut.sprx"'),
 
+    ("stable sysctl game discovery",
+     "src/ps5/v1_stable_ps5_platform.cpp",
+     "KERN_PROC_PROC"),
+
+    ("stable eboot process name",
+     "src/ps5/v1_stable_ps5_platform.cpp",
+     'find_process_sysctl("eboot.bin")'),
+
     ("stable DMAP read model",
      "src/reconstruction/v1_stable_memory.cpp",
      "proc_read_dmap"),
@@ -129,6 +137,17 @@ reconstruction_text = "\n".join(
 for forbidden in ("pt_attach(", "pt_copyout(", "pt_detach("):
     ok = forbidden not in reconstruction_text
     print(f"{'PASS' if ok else 'FAIL'}  no parity per-read ptrace: {forbidden}")
+    failed |= not ok
+
+# Hardware v2 probe proved that the clean rewrite's etaHEN allproc helper was
+# not equivalent to the stable line's process discovery. Keep the reconstructed
+# platform on sysctl/find_pid for game lookup/liveness.
+platform = (root / "src" / "ps5" / "v1_stable_ps5_platform.cpp").read_text(
+    encoding="utf-8"
+)
+for forbidden in ("base_.find_game_process()", "base_.process_alive("):
+    ok = forbidden not in platform
+    print(f"{'PASS' if ok else 'FAIL'}  no clean-rewrite process helper: {forbidden}")
     failed |= not ok
 
 if failed:

--- a/tools/check_v1_source_gate.py
+++ b/tools/check_v1_source_gate.py
@@ -5,56 +5,100 @@ import sys
 root = Path(__file__).resolve().parents[1]
 
 checks = [
-    ("integer FPS",
-     "include/common_fps/types.hpp",
-     "int fps = 0"),
+    ("stable PHUF magic",
+     "include/common_fps/v1_stable_wire.hpp",
+     "kWireMagic = 0x46554850u"),
 
-    ("font 26",
-     "include/common_fps/constants.hpp",
-     "kDefaultFontSize = 26"),
+    ("stable UDP port 55541",
+     "include/common_fps/v1_stable_wire.hpp",
+     "kWirePort = 55541"),
 
-    ("payload args",
+    ("stable packet size 0x420",
+     "include/common_fps/v1_stable_wire.hpp",
+     "sizeof(FpsPacket) == 0x420"),
+
+    ("stable loading payload",
+     "include/common_fps/v1_stable_wire.hpp",
+     '"FPS\\tloading\\n"'),
+
+    ("stable tenth-FPS calculation",
+     "include/common_fps/v1_stable_wire.hpp",
+     "10000000ull"),
+
+    ("stable VideoOut sampler",
+     "src/reconstruction/v1_stable_sampler.cpp",
+     '"libSceVideoOut.sprx"'),
+
+    ("stable odd/even publisher",
+     "src/reconstruction/v1_stable_hook_state.cpp",
+     "sequence_.fetch_add"),
+
+    ("stable 30-tick label delay",
+     "include/common_fps/v1_stable_render_loop.hpp",
+     "kLabelDelayTicks = 30"),
+
+    ("payload args retained",
      "integration/loader/v1_loader_contract.cpp",
      "prepare_payload_args()"),
 
-    ("Scene readiness",
+    ("Scene readiness retained",
      "integration/loader/v1_loader_contract.cpp",
      "wait_for_shellui_scene()"),
+
+    ("image-load phase explicit",
+     "integration/loader/v1_loader_contract.cpp",
+     "load_renderer_image"),
 
     ("single loader session",
      "docs/V1_0_0_PARITY_CONTRACT.md",
      "Do not break one loader session"),
 
-    ("autoload stable readiness",
+    ("font 26",
+     "include/common_fps/constants.hpp",
+     "kDefaultFontSize = 26"),
+
+    ("autoload stable readiness retained for later",
      "src/core/autoload_guard.cpp",
      "consecutive_ready_"),
 
-    ("autoload retry",
-     "src/core/autoload_guard.cpp",
-     "schedule_retry"),
-
-    ("autoload renderer health",
-     "src/core/autoload_guard.cpp",
-     "renderer_alive()"),
-
-    ("scene self-heal",
-     "src/core/scene_guard.cpp",
-     "widgets_alive()"),
-
-    ("FW 9.60 autoload regression documented",
+    ("FW 9.60 regression documented",
      "docs/AUTOLOAD_REGRESSION_FW960.md",
      "Stop")
 ]
 
 failed = False
-
 for label, rel, needle in checks:
     text = (root / rel).read_text(encoding="utf-8")
     ok = needle in text
     print(f"{'PASS' if ok else 'FAIL'}  {label}")
     failed |= not ok
 
+# The recovered stable shsrv order is image first, payload args second, exec
+# preparation third. The old reconstruction had args before image and must not
+# silently regress back to that ordering.
+loader = (root / "integration/loader/v1_loader_contract.cpp").read_text(
+    encoding="utf-8"
+)
+order = [
+    loader.find("load_renderer_image"),
+    loader.find("prepare_payload_args()"),
+    loader.find("prepare_exec"),
+]
+order_ok = all(pos >= 0 for pos in order) and order == sorted(order)
+print(f"{'PASS' if order_ok else 'FAIL'}  image -> payload args -> exec order")
+failed |= not order_ok
+
+# A separate post-load continue_target() belonged to the inaccurate clean-room
+# model. Stable Trace Continue is internal to image loading and final resume is
+# the end of the same loader session.
+no_extra_continue = "continue_target()" not in loader
+print(
+    f"{'PASS' if no_extra_continue else 'FAIL'}  "
+    "no extra post-load continue_target"
+)
+failed |= not no_extra_continue
+
 if failed:
     sys.exit(1)
 
-print("v1.0.0 + safe-autoload source gate: PASS")
+print("stable v1.0.0 reconstruction source gate: PASS")

--- a/tools/check_v1_source_gate.py
+++ b/tools/check_v1_source_gate.py
@@ -47,7 +47,11 @@ checks = [
 
     ("stable dynlib module discovery",
      "src/ps5/v1_stable_ps5_platform.cpp",
-     "SYS_dl_get_list"),
+     "kSysDlGetList"),
+
+    ("minimal dynlib ABI isolated from kernel structs",
+     "src/ps5/v1_stable_dynlib.hpp",
+     "struct DynlibModuleInfo"),
 
     ("FW 9.60 module basename fallback",
      "src/ps5/v1_stable_ps5_platform.cpp",

--- a/tools/check_v1_source_gate.py
+++ b/tools/check_v1_source_gate.py
@@ -45,6 +45,14 @@ checks = [
      "src/ps5/v1_stable_ps5_platform.cpp",
      'find_process_sysctl("eboot.bin")'),
 
+    ("stable dynlib module discovery",
+     "src/ps5/v1_stable_ps5_platform.cpp",
+     "SYS_dl_get_list"),
+
+    ("FW 9.60 module basename fallback",
+     "src/ps5/v1_stable_ps5_platform.cpp",
+     "module_name_matches"),
+
     ("stable DMAP read model",
      "src/reconstruction/v1_stable_memory.cpp",
      "proc_read_dmap"),
@@ -101,9 +109,6 @@ for label, rel, needle in checks:
     print(f"{'PASS' if ok else 'FAIL'}  {label}")
     failed |= not ok
 
-# The recovered stable shsrv order is image first, payload args second, exec
-# preparation third. The old reconstruction had args before image and must not
-# silently regress back to that ordering.
 loader = (root / "integration/loader/v1_loader_contract.cpp").read_text(
     encoding="utf-8"
 )
@@ -116,9 +121,6 @@ order_ok = all(pos >= 0 for pos in order) and order == sorted(order)
 print(f"{'PASS' if order_ok else 'FAIL'}  image -> payload args -> exec order")
 failed |= not order_ok
 
-# A separate post-load continue_target() belonged to the inaccurate clean-room
-# model. Stable Trace Continue is internal to image loading and final resume is
-# the end of the same loader session.
 no_extra_continue = "continue_target()" not in loader
 print(
     f"{'PASS' if no_extra_continue else 'FAIL'}  "
@@ -126,9 +128,6 @@ print(
 )
 failed |= not no_extra_continue
 
-# Stable v1.0.0 sampled game VideoOut through PHU's DMAP proc_read path.
-# Per-read ptrace was introduced only by the later clean rewrite. Keep ptrace
-# primitives completely out of the reconstructed parity core.
 reconstruction_dir = root / "src" / "reconstruction"
 reconstruction_text = "\n".join(
     path.read_text(encoding="utf-8")
@@ -139,15 +138,16 @@ for forbidden in ("pt_attach(", "pt_copyout(", "pt_detach("):
     print(f"{'PASS' if ok else 'FAIL'}  no parity per-read ptrace: {forbidden}")
     failed |= not ok
 
-# Hardware v2 probe proved that the clean rewrite's etaHEN allproc helper was
-# not equivalent to the stable line's process discovery. Keep the reconstructed
-# platform on sysctl/find_pid for game lookup/liveness.
 platform = (root / "src" / "ps5" / "v1_stable_ps5_platform.cpp").read_text(
     encoding="utf-8"
 )
-for forbidden in ("base_.find_game_process()", "base_.process_alive("):
+for forbidden in (
+    "base_.find_game_process()",
+    "base_.process_alive(",
+    "base_.find_module(",
+):
     ok = forbidden not in platform
-    print(f"{'PASS' if ok else 'FAIL'}  no clean-rewrite process helper: {forbidden}")
+    print(f"{'PASS' if ok else 'FAIL'}  no clean-rewrite platform helper: {forbidden}")
     failed |= not ok
 
 if failed:

--- a/tools/check_v1_source_gate.py
+++ b/tools/check_v1_source_gate.py
@@ -57,6 +57,14 @@ checks = [
      "src/ps5/v1_stable_ps5_platform.cpp",
      "module_name_matches"),
 
+    ("etaHEN debugger auth parity",
+     "src/ps5/v1_parity_probe_main.cpp",
+     "set_ucred_to_debugger()"),
+
+    ("debugger auth restored after probe",
+     "src/ps5/v1_parity_probe_main.cpp",
+     "restore_authid(old_authid)"),
+
     ("stable DMAP read model",
      "src/reconstruction/v1_stable_memory.cpp",
      "proc_read_dmap"),
@@ -153,6 +161,20 @@ for forbidden in (
     ok = forbidden not in platform
     print(f"{'PASS' if ok else 'FAIL'}  no clean-rewrite platform helper: {forbidden}")
     failed |= not ok
+
+cmake = (root / "ps5" / "CMakeLists.txt").read_text(encoding="utf-8")
+ucred_linked = '"${ETAHEN_FPS}/src/ucred.cpp"' in cmake
+print(f"{'PASS' if ucred_linked else 'FAIL'}  etaHEN ucred.cpp linked into parity probe")
+failed |= not ucred_linked
+
+probe = (root / "src" / "ps5" / "v1_parity_probe_main.cpp").read_text(
+    encoding="utf-8"
+)
+auth_pos = probe.find("set_ucred_to_debugger()")
+scan_pos = probe.find("log_dynlib_scan(*pid)")
+auth_order_ok = auth_pos >= 0 and scan_pos >= 0 and auth_pos < scan_pos
+print(f"{'PASS' if auth_order_ok else 'FAIL'}  debugger auth before target dynlib scan")
+failed |= not auth_order_ok
 
 if failed:
     sys.exit(1)

--- a/tools/compare_phu_r11_donor.py
+++ b/tools/compare_phu_r11_donor.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from analyze_v1_stable import Elf64, unwrap_plugin, sha256_bytes
+
+KNOWN_DONOR_SHA256 = "8e20deefb9100705be8352dc6acb47241c6a044b93dc3f578f93c424789b2622"
+KNOWN_STABLE_ELF_SHA256 = "6a66da88a99fa8757bf5c649e388d777a10768cd444d9f4cf82649e4592e292c"
+KNOWN_DONOR_RENDERER_SHA256 = "8d1490ac7d1ba589044108675e29a1d3cc05a0a946556d52aeb502d114ea7eca"
+KNOWN_STABLE_RENDERER_SHA256 = "3640cbcaf907bc900e257503b3c8922fdbc129c492a76a2348fd75c84f68b91c"
+RENDERER_START = "_binary_libphu_overlay_so_start"
+RENDERER_END = "_binary_libphu_overlay_so_end"
+
+
+def section_bytes(elf: Elf64, name: str) -> bytes:
+    sec = next((s for s in elf.sections if s.name == name), None)
+    if sec is None or sec.sh_type == 8:
+        return b""
+    return elf.data[sec.offset: sec.offset + sec.size]
+
+
+def build_id(elf: Elf64) -> str | None:
+    blob = section_bytes(elf, ".note.gnu.build-id")
+    if len(blob) < 16:
+        return None
+    namesz = int.from_bytes(blob[0:4], "little")
+    descsz = int.from_bytes(blob[4:8], "little")
+    desc_off = (12 + namesz + 3) & ~3
+    if desc_off + descsz > len(blob):
+        return None
+    return blob[desc_off:desc_off + descsz].hex()
+
+
+def extract_renderer(elf: Elf64) -> bytes:
+    starts = elf.symbols_named(RENDERER_START)
+    ends = elf.symbols_named(RENDERER_END)
+    if not starts or not ends:
+        raise ValueError("embedded renderer symbols missing")
+    start = starts[0].value
+    end = ends[0].value
+    if end <= start:
+        raise ValueError("invalid renderer range")
+    start_off = elf.va_to_file_offset(start)
+    end_off = elf.va_to_file_offset(end - 1) + 1
+    return elf.data[start_off:end_off]
+
+
+def diff_runs(a: bytes, b: bytes) -> list[tuple[int, int]]:
+    n = min(len(a), len(b))
+    positions = [i for i in range(n) if a[i] != b[i]]
+    if len(a) != len(b):
+        positions.extend(range(n, max(len(a), len(b))))
+    if not positions:
+        return []
+
+    runs: list[tuple[int, int]] = []
+    start = previous = positions[0]
+    for pos in positions[1:]:
+        if pos == previous + 1:
+            previous = pos
+            continue
+        runs.append((start, previous + 1))
+        start = previous = pos
+    runs.append((start, previous + 1))
+    return runs
+
+
+def touched_functions(elf: Elf64, section_name: str, runs: list[tuple[int, int]]) -> list[str]:
+    sec = next((s for s in elf.sections if s.name == section_name), None)
+    if sec is None:
+        return []
+
+    funcs = sorted(
+        (s.value, s.name)
+        for s in elf.symbols
+        if s.st_type == 2
+        and s.name
+        and s.shndx == sec.index
+        and sec.addr <= s.value < sec.addr + sec.size
+    )
+
+    out: list[str] = []
+    for start, _end in runs:
+        va = sec.addr + start
+        name = None
+        for func_va, func_name in funcs:
+            if func_va > va:
+                break
+            name = func_name
+        if name and name not in out:
+            out.append(name)
+    return out
+
+
+def compare_alloc_sections(a: Elf64, b: Elf64) -> dict[str, dict[str, int]]:
+    out: dict[str, dict[str, int]] = {}
+    for sa in a.sections:
+        if not (sa.flags & 0x2) or sa.sh_type == 8:
+            continue
+        sb = next((s for s in b.sections if s.name == sa.name), None)
+        if sb is None or sb.sh_type == 8:
+            continue
+        da = a.data[sa.offset:sa.offset + sa.size]
+        db = b.data[sb.offset:sb.offset + sb.size]
+        changed = sum(x != y for x, y in zip(da, db)) + abs(len(da) - len(db))
+        if changed:
+            out[sa.name] = {
+                "donor_size": len(da),
+                "stable_size": len(db),
+                "changed_bytes": changed,
+            }
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Compare PHU v1.14.25-r11 donor to Common FPS v1.0.0"
+    )
+    ap.add_argument("donor_elf", type=Path)
+    ap.add_argument("stable", type=Path, help="Common FPS v1.0.0 .plugin or .elf")
+    ap.add_argument("--json", type=Path)
+    args = ap.parse_args()
+
+    donor_raw = args.donor_elf.read_bytes()
+    stable_raw = args.stable.read_bytes()
+    stable_elf_raw, _meta = unwrap_plugin(stable_raw)
+
+    donor = Elf64(donor_raw)
+    stable = Elf64(stable_elf_raw)
+    donor_renderer_raw = extract_renderer(donor)
+    stable_renderer_raw = extract_renderer(stable)
+    donor_renderer = Elf64(donor_renderer_raw)
+    stable_renderer = Elf64(stable_renderer_raw)
+
+    outer_text_a = section_bytes(donor, ".text")
+    outer_text_b = section_bytes(stable, ".text")
+    outer_runs = diff_runs(outer_text_a, outer_text_b)
+
+    renderer_text_a = section_bytes(donor_renderer, ".text")
+    renderer_text_b = section_bytes(stable_renderer, ".text")
+    renderer_runs = diff_runs(renderer_text_a, renderer_text_b)
+    renderer_ro_a = section_bytes(donor_renderer, ".rodata")
+    renderer_ro_b = section_bytes(stable_renderer, ".rodata")
+
+    report = {
+        "donor": {
+            "size": len(donor_raw),
+            "sha256": sha256_bytes(donor_raw),
+            "known_match": sha256_bytes(donor_raw) == KNOWN_DONOR_SHA256,
+            "build_id": build_id(donor),
+        },
+        "stable": {
+            "size": len(stable_elf_raw),
+            "sha256": sha256_bytes(stable_elf_raw),
+            "known_match": sha256_bytes(stable_elf_raw) == KNOWN_STABLE_ELF_SHA256,
+            "build_id": build_id(stable),
+        },
+        "outer_text": {
+            "changed_bytes": sum(end - start for start, end in outer_runs),
+            "changed_runs": len(outer_runs),
+            "touched_functions": touched_functions(donor, ".text", outer_runs),
+        },
+        "renderer": {
+            "size": len(donor_renderer_raw),
+            "donor_sha256": sha256_bytes(donor_renderer_raw),
+            "stable_sha256": sha256_bytes(stable_renderer_raw),
+            "donor_known_match": sha256_bytes(donor_renderer_raw) == KNOWN_DONOR_RENDERER_SHA256,
+            "stable_known_match": sha256_bytes(stable_renderer_raw) == KNOWN_STABLE_RENDERER_SHA256,
+            "donor_build_id": build_id(donor_renderer),
+            "stable_build_id": build_id(stable_renderer),
+            "text_changed_bytes": sum(end - start for start, end in renderer_runs),
+            "rodata_changed_bytes": (
+                sum(x != y for x, y in zip(renderer_ro_a, renderer_ro_b))
+                + abs(len(renderer_ro_a) - len(renderer_ro_b))
+            ),
+            "touched_functions": touched_functions(donor_renderer, ".text", renderer_runs),
+            "alloc_section_diff": compare_alloc_sections(donor_renderer, stable_renderer),
+        },
+    }
+
+    print(json.dumps(report, indent=2))
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Reconstruct the open-source implementation from the hardware-stable v1.0.0 / internal v0.28b architecture instead of the rejected Stage B/B2/B3 ShellUI redesign.

This PR is reconstruction groundwork. It does **not** change the PS5 runtime or produce a new hardware candidate yet.

## Stable v1.0.0 forensic tooling

Added `tools/analyze_v1_stable.py` and tests to verify the historical stable plugin/ELF, inventory retained compilation units and extract the embedded renderer without committing historical binaries.

Known stable hashes:

- etaHEN plugin: `f1240511bfe3cb17a3db6f4d099cf3cd69be678d10901425a7b33911265195e1`
- payload ELF: `6a66da88a99fa8757bf5c649e388d777a10768cd444d9f4cf82649e4592e292c`
- stable embedded renderer: `3640cbcaf907bc900e257503b3c8922fdbc129c492a76a2348fd75c84f68b91c`

## Exact PHU r11 donor relationship recovered

The original `PHU Games Tools v1.14.25-r11/phu_overlay.elf` supplied by the project owner was compared locally to the stable Common FPS v1.0.0 payload.

Donor facts:

- PHU r11 ELF SHA256: `8e20deefb9100705be8352dc6acb47241c6a044b93dc3f578f93c424789b2622`
- donor and stable payload size: `1,555,144` bytes each
- donor and stable outer Build ID: `4fcee90fdb9656b3ff5026338c0846de`
- donor and stable symbol addresses/layout match

Outer payload allocatable `.text` delta:

- only `1,350` changed bytes in `45` runs
- changed text maps only to `main`, `probe_main_entry`, and `elfldr_load`

Embedded renderer:

- same symbol range and size: `260,248` bytes
- donor renderer SHA256: `8d1490ac7d1ba589044108675e29a1d3cc05a0a946556d52aeb502d114ea7eca`
- stable renderer SHA256: `3640cbcaf907bc900e257503b3c8922fdbc129c492a76a2348fd75c84f68b91c`
- both renderer Build ID: `c6ee2731d817d85466e9fbef5be7de79`
- runtime delta is only `120` bytes in `.text` and `25` bytes in `.rodata`
- changed renderer text maps only to `elf_main`, `read_cfg_v13`, `phu_set_fps_text_raw`, `phu_create_fps_label`, `install_onrender_hook`, and `OnRender_Hook`

The donor renderer is unstripped and preserves full symbols + DWARF, including the original compilation directory `D:/dump/Claude Code/PHU Overlay/payload/shellui_overlay` and source-unit names. This gives us a high-confidence reconstruction map.

Added:

- `tools/compare_phu_r11_donor.py`
- `docs/PHU_V1_14_25_R11_DONOR_DELTA.md`
- `tests/test_phu_donor_compare.py`

The donor binary itself is intentionally **not** committed to the source tree.

## Reconstruction rule

First reproduce manual-run hardware parity with the stable v1.0.0 loader/renderer contract. Only after that add an autoload readiness gate around the proven initialization.

Do not introduce another independent `Application.Update` hook.

Draft until the reconstructed source reaches hardware parity.