### PR TITLE
Promote TEST31 as hardware-validated v1.1.0

### DIFF
--- a/.github/workflows/ps5-source-build.yml
+++ b/.github/workflows/ps5-source-build.yml
@@ -2,10 +2,21 @@ name: PS5 Source Build
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "include/**"
+      - "ps5/**"
+      - "scripts/**"
+      - "tools/**"
+      - ".github/workflows/ps5-source-build.yml"
+      - "CMakeLists.txt"
+      - "DEPENDENCIES.lock.json"
   push:
-    tags:
-      - "v1.1.0-rc*"
-      - "v1.1.0"
+    branches:
+      - parity-test31-tracked-renderer
 
 jobs:
   build:
@@ -38,10 +49,10 @@ jobs:
       - name: Upload PS5 build
         uses: actions/upload-artifact@v4
         with:
-          name: Common-FPS-for-PS5-v1.1.0-source-build
+          name: Common-FPS-PARITY-TEST31-tracked-renderer
           path: |
-            dist/Common_FPS_PS5_v1.1.0.elf
-            dist/Common_FPS_PS5_etaHEN_v1.1.0.plugin
+            dist/Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf
+            dist/Common_FPS_PS5_etaHEN_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.plugin
             dist/Common_FPS_ShellUI_v1.1.0.elf
             dist/SHA256SUMS.txt
             RESOLVED_BUILD_DEPENDENCIES.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/build*/
+/dist/
+/RESOLVED_BUILD_DEPENDENCIES.txt
+__pycache__/
+*.pyc

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,4 +1,4 @@
-# Building PARITY TEST31
+# Building v1.1.0 (PARITY TEST31)
 
 ## GitHub Actions
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,59 +1,47 @@
-# Building Common FPS for PS5
+# Building PARITY TEST31
 
-## Recommended: GitHub Actions
+## GitHub Actions
 
-Windows users do not need WSL.
+Open **Actions → PS5 Source Build → Run workflow**. The workflow prepares the
+pinned dependencies, runs host tests, builds the PS5 controller and verifies
+the output wrapper and diagnostic boundary.
 
-Upload this repository to GitHub, then:
-
-```text
-Actions
--> PS5 Source Build
--> Run workflow
-```
-
-The workflow downloads the pinned PS5 Payload SDK and GPL upstream source
-dependencies, runs source gates/tests, and prepares the PS5 build workspace.
-
-When the cross-build target succeeds, the workflow uploads:
+The downloadable artifact contains:
 
 ```text
-Common_FPS_PS5_v1.1.0.elf
-Common_FPS_PS5_etaHEN_v1.1.0.plugin
-```
-
-as workflow artifacts.
-
-## Host tests
-
-On a normal C++17 environment:
-
-```bash
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build
-ctest --test-dir build --output-on-failure
-```
-
-Also run:
-
-```bash
-python3 tools/check_v1_source_gate.py
-python3 tests/test_plugin_wrapper.py
+Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf
+Common_FPS_PS5_etaHEN_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.plugin
+SHA256SUMS.txt
+RESOLVED_BUILD_DEPENDENCIES.txt
 ```
 
 ## Local PS5 build
 
-A POSIX build host is optional. The build environment is defined by
-`.github/workflows/ps5-source-build.yml`.
+On a POSIX host with the required build tools:
 
-Pinned dependencies are listed in:
-
-```text
-DEPENDENCIES.lock.json
+```bash
+bash ./scripts/prepare_ps5_deps.sh
+bash ./scripts/ps5_source_build.sh
 ```
 
-## Release rule
+`scripts/ps5_source_build.sh` invokes
+`tools/verify_test31_artifact.py`. The reference build produced:
 
-A successful compiler run is not enough to declare a stable PS5 release.
+```text
+360f9103d552b1c812febe4bcfc16647cf5497475592154d1273fdb379a6cfea  ELF
+b68f2242434773c2b65393b0f06b4b1db926e14e8f5d51b2e8b2e358d3e1832b  plugin
+```
 
-The produced binaries must also pass `docs/HARDWARE_TEST_PLAN_FW960.md`.
+## Host tests
+
+```bash
+cmake -S . -B build-host -DCMAKE_BUILD_TYPE=Release
+cmake --build build-host
+ctest --test-dir build-host --output-on-failure
+python3 tests/test_plugin_wrapper.py
+```
+
+## Runtime limitation
+
+TEST31 samples FPS in the background and sends integer state to the embedded
+ShellUI renderer. The first valid result for each game PID is also logged.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -28,8 +28,8 @@ bash ./scripts/ps5_source_build.sh
 `tools/verify_test31_artifact.py`. The reference build produced:
 
 ```text
-360f9103d552b1c812febe4bcfc16647cf5497475592154d1273fdb379a6cfea  ELF
-b68f2242434773c2b65393b0f06b4b1db926e14e8f5d51b2e8b2e358d3e1832b  plugin
+2db81cb2f896eb5310e22715226cc065e1b2c22304f6376c0fdbac5ce32b9f3a  ELF
+fefdab4c49fc58eddfd798697d1479818367db67d6543f1994809d3002fcbc19  plugin
 ```
 
 ## Host tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,3 +48,18 @@ if(COMMON_FPS_BUILD_TESTS)
     target_link_libraries(common_fps_autoload_tests PRIVATE common_fps_core)
     add_test(NAME common_fps_autoload_tests COMMAND common_fps_autoload_tests)
 endif()
+
+if(COMMON_FPS_BUILD_TESTS)
+    # These tests use assert(), including calls inside assertions. Keep the
+    # checks active in Release builds used by CI.
+    foreach(common_fps_test_target IN ITEMS
+            common_fps_tests
+            common_fps_v1_parity_tests
+            common_fps_autoload_tests)
+        if(MSVC)
+            target_compile_options(${common_fps_test_target} PRIVATE /UNDEBUG)
+        else()
+            target_compile_options(${common_fps_test_target} PRIVATE -UNDEBUG)
+        endif()
+    endforeach()
+endif()

--- a/DEPENDENCIES.lock.json
+++ b/DEPENDENCIES.lock.json
@@ -1,6 +1,6 @@
 {
   "project": "Common FPS for PS5",
-  "version": "1.1.0-rc1",
+  "version": "1.1.0-parity-test31",
   "license": "GPL-3.0-or-later",
   "ps5_payload_sdk": {
     "repository": "https://github.com/ps5-payload-dev/sdk",
@@ -12,11 +12,12 @@
     "repository": "https://github.com/etaHEN/etaHEN",
     "version": "2.4B",
     "commit": "d47f99bd37f349ae59b3c4b66e09e93ba69f56cd",
-    "purpose": "Pinned GPL source baseline for PS5 process and ShellUI/PUI integration; 2.4B introduced Game Overlay and 8.40-10.01 fixes without the later 2.5B dumper/WebMAN IPC mismatch encountered by the Common FPS minimal renderer build."
+    "purpose": "Pinned GPL source baseline used by the TEST20 process/module sampling adapter. Runtime hardware test used etaHEN 2.6."
   },
   "ps5_payload_shsrv": {
     "repository": "https://github.com/ps5-payload-dev/shsrv",
     "version": "v0.20",
-    "purpose": "GPL reference/source for ptrace ELF loader and payload-args contract"
+    "commit": "6f320637d56d344a0e7797753099e33238bbf146",
+    "purpose": "Pinned GPL ptrace and ELF-loader primitives used by the source-built ShellUI bootstrap."
   }
 }

--- a/DEPENDENCIES.lock.json
+++ b/DEPENDENCIES.lock.json
@@ -1,6 +1,6 @@
 {
   "project": "Common FPS for PS5",
-  "version": "1.1.0-parity-test31",
+  "version": "1.1.0",
   "license": "GPL-3.0-or-later",
   "ps5_payload_sdk": {
     "repository": "https://github.com/ps5-payload-dev/sdk",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Common FPS for PS5 — PARITY TEST31 tracked renderer
+# Common FPS for PS5 — v1.1.0 (PARITY TEST31)
 
-This experimental branch contains TEST30's tracked-process lifecycle and the
-source-built renderer/IPC path that previously produced the visible counter:
+This hardware-validated source snapshot combines TEST30's tracked-process
+lifecycle with the source-built renderer/IPC path that produces the visible
+counter:
 
 ```text
 Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf
@@ -20,7 +21,7 @@ embedded 70,968-byte source renderer and one-way state packets.
 
 ## Scope
 
-TEST31 is a diagnostic visual-counter test, not a stable release. It:
+The TEST31 implementation:
 
 - preserves the source-reproduced TEST20 sampler and observer;
 - removes only Common FPS's internal `fork()`;
@@ -36,16 +37,17 @@ TEST31 is a diagnostic visual-counter test, not a stable release. It:
 - injects it with the target-stack bootstrap and restores controller Auth-ID;
 - sends one validated loopback state packet per second;
 - creates and updates the integer FPS widget on ShellUI's update hook;
-- contains no shutdown recorder or shutdown-time file writes.
+- contains no shutdown recorder or shutdown-time file writes;
+- passed repeated PS5 runs with a visible counter in two games and normal
+  system-menu restarts.
 
-TEST30 was hardware-validated with two games and a normal restart. TEST31 still
-requires the combined hardware gate: visible integer FPS in both games and a
-normal restart. The source-identical TEST20 baseline remains on branch
-`parity-test20-source`.
+The submitted TEST31 log records `ShellUI renderer online`, `first_fps=59` and
+`first_fps=60` for two game PIDs. The user also confirmed repeated normal
+restarts without an improper-shutdown warning. The source-identical TEST20
+baseline remains on branch `parity-test20-source`.
 
-The public, visually complete `v1.0.0` remains the stable user release. The
-renderer-enabled v1.1.x experiments remain experimental because their restart
-regression is unresolved.
+The visually complete `v1.0.0` release remains available as a fallback. TEST31
+is the promoted v1.1.0 source snapshot.
 
 ## Build
 
@@ -60,6 +62,9 @@ For local build details, see [BUILDING.md](BUILDING.md).
 
 The exact hardware procedure is in
 [docs/PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md](docs/PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md).
+The submitted run is retained at
+[docs/evidence/PARITY_TEST31_HARDWARE_20260905.log](docs/evidence/PARITY_TEST31_HARDWARE_20260905.log)
+(`sha256=7a2c1f27835e31026b663fdbe44e58a3d59e6675d5963073a626838ecb90a95c`).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,182 +1,69 @@
-# Common FPS for PS5
+# Common FPS for PS5 — PARITY TEST31 tracked renderer
 
-A lightweight, open-source real-time FPS counter for PlayStation 5.
-
-> **Current source release:** `v1.1.0
-> **Hardware-stable binary baseline:** `v1.0.0`  
-> **License:** GPL-3.0-or-later
-
-## What it does
-
-Common FPS shows a minimal FPS overlay without patching the game's rendering
-code.
-
-Default appearance:
+This experimental branch contains TEST30's tracked-process lifecycle and the
+source-built renderer/IPC path that previously produced the visible counter:
 
 ```text
-FPS: 59
+Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf
+Common_FPS_PS5_etaHEN_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.plugin
 ```
 
-- integer FPS only;
-- `FPS:` in purple (`#B366FF`);
-- value in white;
-- font size `26`;
-- bottom-left by default;
-- fixed position with no horizontal drift.
+The controller runs in the process already spawned and recorded by etaHEN
+instead of creating an untracked child with a second `fork()`. The sampler is
+unchanged from the hardware-successful TEST30 run. TEST31 adds only the
+embedded 70,968-byte source renderer and one-way state packets.
 
-## Stable design inherited from v1.0.0
+| Artifact | Expected SHA-256 |
+|---|---|
+| ELF | `360f9103d552b1c812febe4bcfc16647cf5497475592154d1273fdb379a6cfea` |
+| plugin | `b68f2242434773c2b65393b0f06b4b1db926e14e8f5d51b2e8b2e358d3e1832b` |
 
-The source rewrite preserves the behavior that was validated on PS5 FW 9.60:
+## Scope
 
-- read-only FPS acquisition;
-- no game rendering hooks;
-- no game-memory FPS patches;
-- game PID reset/re-discovery;
-- persistent `Game A -> Home -> Game B` lifecycle;
-- asynchronous startup;
-- ShellUI/PUI rendering;
-- Scene readiness requirement;
-- complete payload-args loader contract.
+TEST31 is a diagnostic visual-counter test, not a stable release. It:
 
-## FPS source
+- preserves the source-reproduced TEST20 sampler and observer;
+- removes only Common FPS's internal `fork()`;
+- keeps the etaHEN-spawned PID resident and trackable;
+- discovers `eboot.bin` through the FW 9.60 `KERN_PROC` layout;
+- resolves `libSceVideoOut.sprx`;
+- reads the VideoOut counter through the FW 9.60 DMAP page walk;
+- calculates one-second integer FPS samples;
+- follows game PID changes;
+- writes one first-sample record for each game PID;
+- embeds the exact 70,968-byte renderer used by the successful TEST21 visual
+  run;
+- injects it with the target-stack bootstrap and restores controller Auth-ID;
+- sends one validated loopback state packet per second;
+- creates and updates the integer FPS widget on ShellUI's update hook;
+- contains no shutdown recorder or shutdown-time file writes.
 
-The documented stable sampler resolves a VideoOut counter through:
+TEST30 was hardware-validated with two games and a normal restart. TEST31 still
+requires the combined hardware gate: visible integer FPS in both games and a
+normal restart. The source-identical TEST20 baseline remains on branch
+`parity-test20-source`.
 
-```text
-eboot.bin
-  -> libSceVideoOut.sprx
-  -> base + 0x34980
-  -> 7 probe records (0x18 bytes each)
-  -> first enabled record
-  -> root pointer
-  -> root + 0x768
-  -> uint32 counter
-```
+The public, visually complete `v1.0.0` remains the stable user release. The
+renderer-enabled v1.1.x experiments remain experimental because their restart
+regression is unresolved.
 
-FPS is calculated from counter delta and monotonic elapsed time.
+## Build
 
-Only the final integer FPS value is exposed to the overlay.
+The easiest reproducible build is the GitHub Actions workflow **PS5 Source
+Build**. It pins PS5 Payload SDK v0.41 and etaHEN source 2.4B
+(`d47f99bd37f349ae59b3c4b66e09e93ba69f56cd`). The tested runtime was etaHEN
+2.6; the pinned 2.4B tree is a build dependency.
 
-## Safe etaHEN autoload
+For local build details, see [BUILDING.md](BUILDING.md).
 
-A hardware test of public `v1.0.0` found an etaHEN autoload startup race on
-FW 9.60: the plugin could start before ShellUI was ready, later appear enabled
-without a live renderer, and a game launch could end in a KP.
+## Evidence
 
-`v1.1.0-rc1` therefore includes a persistent Safe Autoload state machine:
-
-```text
-autoload
-  -> return to etaHEN quickly
-  -> worker stays alive
-  -> wait for stable runtime/Scene readiness
-  -> install renderer
-  -> verify renderer health
-  -> retry on failure
-  -> normal FPS lifecycle
-```
-
-The game sampler is not allowed to enter its normal lifecycle while the
-renderer/runtime side is unhealthy.
-
-## Optional overlay configuration
-
-The clean source model supports:
-
-```ini
-[overlay]
-corner=bottom_left
-font_size=26
-margin_x=10
-margin_y=10
-```
-
-Corner values:
-
-```text
-top_left
-top_right
-bottom_left
-bottom_right
-```
-
-The compatibility default remains `bottom_left / 26`.
-
-## Build model
-
-This repository is intended to produce the PS5 artifacts **from source**:
-
-```text
-source
-  + PS5 Payload SDK
-  + pinned GPL upstream source dependencies
-        |
-        v
-Common_FPS_PS5_v1.1.0.elf
-Common_FPS_PS5_etaHEN_v1.1.0.plugin
-```
-
-No PHU ELF/SO binary blob is part of the source-built path.
-
-### GitHub Actions
-
-You do not need Linux or WSL on your own PC.
-
-After uploading the repository to GitHub:
-
-1. open **Actions**;
-2. run **PS5 Source Build**;
-3. download the produced build artifact.
-
-Host tests run automatically on pushes and pull requests.
-
-## Release status
-
-`v1.1.0-rc1` is source-publication ready.
-
-Do **not** mark `v1.1.0` as a hardware-stable release until:
-
-1. the PS5 source-build workflow is green;
-2. the produced ELF/plugin are tested on FW 9.60;
-3. manual startup passes;
-4. etaHEN autoload passes repeated cold boots;
-5. `Game A -> Home -> Game B` passes repeatedly without KP.
-
-The already tested `v1.0.0` remains the recommended binary until that gate
-passes.
-
-## Historical v1.0.0 source status
-
-The historical `v1.0.0` binary was created during an iterative binary-analysis
-and binary-patching workflow involving third-party PS5 homebrew renderer/loader
-mechanisms.
-
-The clean source tree in this repository is therefore **not claimed to be the
-byte-for-byte corresponding source for historical v1.0.0**.
-
-The purpose of `v1.1.x` is to replace that historical workflow with a true
-source-built implementation.
-
-See:
-
-- `docs/SOURCE_STATUS.md`
-- `docs/V1_0_0_PARITY_CONTRACT.md`
-- `docs/AUTOLOAD_REGRESSION_FW960.md`
-- `THIRD_PARTY_NOTICES.md`
+The exact hardware procedure is in
+[docs/PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md](docs/PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md).
 
 ## License
 
-Common FPS-owned source is licensed under the **GNU General Public License
-version 3 or later**.
-
-SPDX:
-
-```text
-GPL-3.0-or-later
-```
-
-Third-party projects retain their own copyright and license notices.
-
-## Disclaimer
+Common FPS-owned source is licensed under GPL-3.0-or-later. Third-party
+projects retain their own licenses and notices.
 
 Homebrew software for modified PlayStation 5 systems. Use at your own risk.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ embedded 70,968-byte source renderer and one-way state packets.
 
 | Artifact | Expected SHA-256 |
 |---|---|
-| ELF | `360f9103d552b1c812febe4bcfc16647cf5497475592154d1273fdb379a6cfea` |
-| plugin | `b68f2242434773c2b65393b0f06b4b1db926e14e8f5d51b2e8b2e358d3e1832b` |
+| ELF | `2db81cb2f896eb5310e22715226cc065e1b2c22304f6376c0fdbac5ce32b9f3a` |
+| plugin | `fefdab4c49fc58eddfd798697d1479818367db67d6543f1994809d3002fcbc19` |
 
 ## Scope
 

--- a/docs/PARITY_TEST20_SAMPLER_ONLY_NO_RECORDER_AB.md
+++ b/docs/PARITY_TEST20_SAMPLER_ONLY_NO_RECORDER_AB.md
@@ -1,0 +1,76 @@
+# PARITY TEST20: sampler-only, no-recorder A/B
+
+## Verified artifacts
+
+```text
+b791baf6f85063d0c7ec57eebcbf60116dff58dfc4ec74aa6d9dedcc1ecc32ef  Common_FPS_PS5_v1.1.0_PARITY_TEST20_SAMPLER_ONLY_NO_RECORDER_AB.elf
+7bdcc16cc582bd89c7f1680471436ef58fdc53bab159c7e36278a5e8f1c8fa49  Common_FPS_PS5_etaHEN_v1.1.0_PARITY_TEST20_SAMPLER_ONLY_NO_RECORDER_AB.plugin
+```
+
+Plugin metadata is `CFPS00039 / 1.28`. Its 29-byte etaHEN header is followed
+by the controller ELF byte-for-byte.
+
+## Runtime contract
+
+```text
+main
+  -> fork()
+  -> parent returns immediately
+  -> child observes ShellUI and samples the active game once per second
+```
+
+The sampling chain is:
+
+```text
+KERN_PROC/sysctl_tdname -> eboot.bin PID
+  -> temporary self debugger Auth ID
+  -> enumerate libSceVideoOut.sprx
+  -> restore the original Auth ID
+  -> read-only FW 9.60 DMAP page walk
+  -> module base + 0x34980
+  -> 7 records x 0x18 bytes
+  -> first enabled record pointer -> uint64 root
+  -> root + 0x768 -> uint32 frame/vsync counter
+  -> elapsed-time delta -> rounded integer FPS
+```
+
+Renderer, ShellUI injection, overlay IPC, custom signal handlers and shutdown
+recording are absent. Therefore no on-screen FPS counter is expected.
+
+## Hardware result
+
+Tested on PS5 FW 9.60 with etaHEN 2.6. The submitted log was:
+
+```text
+Common FPS v1.1.0 PARITY TEST20 sampler-only no-recorder A/B
+Mode=fork-only parent_return=immediate resident_child=active shellui_observation=sysctl_tdname_1s renderer=disabled sampler=videoout_fw960_1s dmap=read_only shutdown_trace=disabled shutdown_writes=disabled signal_handlers=default stop_path=disabled
+Child ready pid=112 ppid=111 first_shellui_pid=58 size_rc=0 data_rc=0 errno=0 bytes=88776 records=24 malformed=0 log_fd=closing periodic_log=disabled platform_log=compile_time_disabled
+Sampler online pid=115 counter=0x800521248 first_fps=60 event_log=once_per_game_pid log_fd=closing
+Sampler online pid=148 counter=0x80053d248 first_fps=59 event_log=once_per_game_pid log_fd=closing
+```
+
+Both games were found and the sampler followed the PID change. The user then
+performed a normal system-menu restart. It completed automatically without a
+physical-button recovery or improper-shutdown warning.
+
+This is one successful hardware run, not proof that every future session will
+restart correctly.
+
+## Reproducibility proof
+
+The TEST20 source was reconstructed from the retained source boundary and the
+unstripped archived ELF. A clean Release build with PS5 Payload SDK v0.41 and
+the pinned etaHEN 2.4B source produced the exact ELF hash above. Wrapping that
+ELF with `CFPS00039 / 1.28` produced the exact plugin hash above. Both rebuilt
+files compared byte-for-byte equal to the submitted hardware-tested files.
+
+`tools/verify_test20_repro.py` enforces the two hashes, plugin metadata, plugin
+body identity and TEST20/renderer-disabled markers during every source build.
+
+## Release status
+
+TEST20 is suitable as an open, reproducible diagnostic baseline. It must not
+be presented as the finished visual FPS counter or promoted to stable v1.1.0.
+The visible renderer added in TEST21 restored live on-screen FPS but also
+restored the restart regression. Later TEST29 failed restart without an
+on-screen renderer, so the overall root cause remains unresolved.

--- a/docs/PARITY_TEST30_TRACKED_PROCESS_NO_FORK_AB.md
+++ b/docs/PARITY_TEST30_TRACKED_PROCESS_NO_FORK_AB.md
@@ -1,0 +1,76 @@
+# PARITY TEST30: etaHEN-tracked process, no internal fork
+
+## Purpose
+
+TEST20 completed one clean hardware restart. TEST21 and TEST29 later produced
+an improper-shutdown warning. Those experiments also showed that the renderer
+alone is not a sufficient explanation, because TEST29 had no visible overlay.
+
+The etaHEN plugin loader already spawns a dedicated process and records that
+PID in `/system_tmp/CFPS00049.PID`. TEST20 through TEST29 then called `fork()`
+again: the recorded parent returned, while the sampler continued in a child
+that etaHEN no longer tracked. TEST30 tests whether that stale process model
+creates a shutdown race.
+
+This is a candidate explanation, not a confirmed root cause. The successful
+TEST20 restart was only one run, and the stable visual v1.0.0 also used a
+historical fork-first startup path.
+
+## Exact A/B boundary
+
+TEST30 is built from the byte-reproduced TEST20 source. The only behavioral
+change is:
+
+```text
+TEST20: etaHEN-spawned process -> fork -> parent exits -> child samples
+TEST30: etaHEN-spawned process -----------------------> process samples
+```
+
+Unchanged:
+
+- FW 9.60 `KERN_PROC` discovery;
+- VideoOut module lookup and Auth-ID restoration;
+- read-only DMAP counter sampling once per second;
+- reattachment after a game PID change;
+- one first-FPS log record per game PID;
+- no renderer, injector, overlay IPC or shutdown recorder;
+- dynamic dependencies: `libkernel_sys`, `libSceLibcInternal`, `libSceNet`.
+
+## Artifacts
+
+```text
+732db78e9329fcabbe93a66972e5d20e5137256769385138348cc88c45a99f9a  Common_FPS_PS5_v1.1.0_PARITY_TEST30_TRACKED_PROCESS_NO_FORK_AB.elf
+b766d1c479cf5720b723fa73caab442bece4048420ed371a70ba6378b49b9515  Common_FPS_PS5_etaHEN_v1.1.0_PARITY_TEST30_TRACKED_PROCESS_NO_FORK_AB.plugin
+```
+
+Plugin metadata: `CFPS00049 / 1.38`. The 29-byte etaHEN header is followed by
+the ELF byte-for-byte.
+
+## Hardware procedure
+
+1. Start from a fresh boot and make sure TEST20, TEST21 and TEST29 are disabled.
+2. Install and activate only the TEST30 plugin.
+3. Start one game and wait at least 15 seconds.
+4. Close it, start a second game and wait at least 15 seconds.
+5. Use **Restart PS5** from the normal system menu while TEST30 is still active.
+6. After boot, report whether the improper-shutdown warning appeared and send
+   `/data/CommonFPS_v110_test30_tracked_process.log` in full.
+
+No on-screen FPS counter is expected in this diagnostic build.
+
+Expected beginning of the log:
+
+```text
+Common FPS v1.1.0 PARITY TEST30 tracked-process no-fork A/B
+Mode=loader-tracked internal_fork=absent spawned_pid=resident ...
+Worker ready pid=... ppid=... first_shellui_pid=...
+Sampler online pid=... counter=... first_fps=...
+```
+
+## Interpretation
+
+- Clean restart: keep the tracked-process lifecycle and next add the renderer
+  on top of it in a separate integration test.
+- Improper restart: the one clean TEST20 run was not a sufficient stability
+  proof; retain the open TEST20 sampler baseline and investigate sampler
+  quiescing/detachment rather than renderer IPC alone.

--- a/docs/PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md
+++ b/docs/PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md
@@ -1,9 +1,9 @@
-# PARITY TEST31: tracked-process renderer, no internal fork
+# PARITY TEST31: hardware-validated tracked-process renderer
 
 TEST30 established the clean process boundary: the etaHEN-created worker stayed
 resident, sampled two games, and the PS5 restarted normally. It deliberately
-omitted the renderer, so no on-screen value was possible. TEST31 changes only
-that missing presentation path.
+omitted the renderer, so no on-screen value was possible. TEST31 added only
+that missing presentation path and has now passed the combined hardware gate.
 
 ## What TEST31 contains
 
@@ -65,6 +65,14 @@ contains no `fork` call, and writes `dist/SHA256SUMS.txt`.
 Also report whether the overlay was visible in both games and whether the
 restart completed automatically without an improper-shutdown warning.
 
+## Confirmed hardware result
+
+The submitted run completed the renderer bootstrap and displayed real FPS in
+two games: `first_fps=59` and `first_fps=60`. The user then performed repeated
+normal system-menu restarts; the console did not show an improper-shutdown
+warning. The complete retained log is
+`docs/evidence/PARITY_TEST31_HARDWARE_20260905.log`.
+
 ## Expected controller log shape
 
 ```text
@@ -79,5 +87,5 @@ Sampler online pid=... first_fps=...
 Sampler online pid=... first_fps=...
 ```
 
-The test is diagnostic. Keep the public, hardware-stable v1.0.0 release as a
-fallback until TEST31 has passed repeated restart checks.
+TEST31 is the promoted v1.1.0 source snapshot. Keep the public v1.0.0 release
+available as a fallback for rollback if a future runtime environment differs.

--- a/docs/PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md
+++ b/docs/PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md
@@ -1,0 +1,83 @@
+# PARITY TEST31: tracked-process renderer, no internal fork
+
+TEST30 established the clean process boundary: the etaHEN-created worker stayed
+resident, sampled two games, and the PS5 restarted normally. It deliberately
+omitted the renderer, so no on-screen value was possible. TEST31 changes only
+that missing presentation path.
+
+## What TEST31 contains
+
+- the TEST30 tracked worker (`internal_fork=absent`);
+- the same FW 9.60 VideoOut counter sampler and read-only DMAP walk;
+- the source-built shared ShellUI ELF embedded once in the controller;
+- the hardware-tested target-stack bootstrap (`PT_ATTACH`, loader, payload
+  arguments, remote `pthread_create`, `PT_DETACH`, original-auth restore);
+- the pinned-Mono/PUI renderer and one-way loopback UDP state packets;
+- no shutdown recorder, custom signal handler, Stop/helper ELF, unhook,
+  unload, injected-thread return or periodic diagnostic writes.
+
+The controller itself never calls `fork()`. The renderer's one resident thread
+is created inside ShellUI by the proven bootstrap; this is why the artifact is
+named “no internal fork”, not “no thread”.
+
+## Artifacts
+
+```text
+dist/Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf
+dist/Common_FPS_PS5_etaHEN_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.plugin
+```
+
+Plugin metadata:
+
+```text
+Title ID: CFPS00050
+Version:  1.39
+```
+
+The build script runs `tools/verify_test31_artifact.py`, checks that `main`
+contains no `fork` call, and writes `dist/SHA256SUMS.txt`.
+
+## Controlled PS5 run
+
+1. Boot the PS5 cleanly and wait for any storage check to finish.
+2. Disable every other Common FPS/PHU plugin and autoload entry. Do not load
+   TEST31 twice in one boot; do not load an earlier test in the same boot.
+3. Activate exactly one TEST31 form. Prefer the `.plugin`; use the `.elf` only
+   as the alternative loader form, never both.
+4. Wait for the short ShellUI bootstrap. The first overlay may say
+   `FPS: Loading`; this is expected until the sampler has a baseline and one
+   discarded warm-up delta.
+5. Start Game A. After about one minute the bottom-left overlay should show an
+   integer such as `FPS: 59` or `FPS: 60`, and the controller log should gain
+   one `Sampler online` line.
+6. Close Game A fully, start Game B without reactivating TEST31, and confirm a
+   second live integer and a second `Sampler online` line.
+7. Close Game B and use the normal system-menu **Restart PS5**. Do not use a
+   physical-button power cut, Stop/helper ELF, or remove
+   `/data/phu_overlay.lock`.
+8. On the next boot, copy the complete controller log before activating any
+   new test:
+
+```text
+/data/CommonFPS_v110_test31_tracked_renderer.log
+```
+
+Also report whether the overlay was visible in both games and whether the
+restart completed automatically without an improper-shutdown warning.
+
+## Expected controller log shape
+
+```text
+Common FPS v1.1.0 PARITY TEST31 tracked-process renderer A/B
+Mode=loader-tracked internal_fork=absent spawned_pid=resident ... renderer=shared_elf_etaHEN_update_hook injection=target_stack_pthread ipc=udp_loopback_1s mono_gc=pinned ...
+Worker ready pid=... first_shellui_pid=... size_rc=0 data_rc=0 ... malformed=0 ...
+ShellUI lookup pid=... via=sysctl_tdname ...
+ShellUI inject start pid=... payload_size=...
+ShellUI bootstrap auth=1/1 attach=1 load=1 args=1 target_stack=1 thread=1 rc=0 detach=1 trace=1/1 imports=.../0 first=none ...
+ShellUI renderer online pid=...
+Sampler online pid=... first_fps=...
+Sampler online pid=... first_fps=...
+```
+
+The test is diagnostic. Keep the public, hardware-stable v1.0.0 release as a
+fallback until TEST31 has passed repeated restart checks.

--- a/docs/SOURCE_STATUS.md
+++ b/docs/SOURCE_STATUS.md
@@ -1,33 +1,20 @@
-# Source status
+# Source status — TEST31
 
-## v1.1.0-rc1
+This branch is the source snapshot for PARITY TEST31.
 
-This repository is the clean source-built successor branch.
+The reference Release build produced:
 
-The source-built path contains no historical PHU renderer ELF/SO blob.
+```text
+360f9103d552b1c812febe4bcfc16647cf5497475592154d1273fdb379a6cfea  ELF
+b68f2242434773c2b65393b0f06b4b1db926e14e8f5d51b2e8b2e358d3e1832b  plugin
+```
 
-Common FPS-owned core, lifecycle, configuration, sampler and Safe Autoload
-logic are published directly as source.
+The snapshot is based on the hardware-validated TEST30 source. Its controller
+still has no internal `fork()` and keeps the sampler in etaHEN's tracked PID;
+TEST31 adds the exact 70,968-byte source renderer, target-stack bootstrap and
+loopback packet sender needed for the on-screen value.
 
-PS5-specific integration is built against pinned/open GPL upstream source.
+TEST30 already passed a two-game hardware run and normal restart. TEST31 is a
+diagnostic candidate until its combined visible-FPS/restart gate passes.
 
-## Hardware-stable baseline
-
-The existing public `v1.0.0` binary remains the hardware-stable baseline for
-manual activation on FW 9.60.
-
-Its historical binary was not originally produced from this clean source tree,
-so this repository does not pretend otherwise.
-
-## Promotion to v1.1.0 stable
-
-The RC becomes stable only when:
-
-1. GitHub `Host Source Tests` passes;
-2. GitHub `PS5 Source Build` passes;
-3. source-built ELF/plugin artifacts are produced;
-4. FW 9.60 manual-start testing passes;
-5. FW 9.60 etaHEN autoload testing passes;
-6. repeated game-switch lifecycle testing passes without KP.
-
-Until then the correct public version label is `v1.1.0-rc1`.
+See [PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md](PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md).

--- a/docs/SOURCE_STATUS.md
+++ b/docs/SOURCE_STATUS.md
@@ -1,6 +1,6 @@
-# Source status — TEST31
+# Source status — v1.1.0 / TEST31
 
-This branch is the source snapshot for PARITY TEST31.
+This snapshot is the source for the hardware-validated v1.1.0 release.
 
 The reference Release build produced:
 
@@ -14,7 +14,11 @@ still has no internal `fork()` and keeps the sampler in etaHEN's tracked PID;
 TEST31 adds the exact 70,968-byte source renderer, target-stack bootstrap and
 loopback packet sender needed for the on-screen value.
 
-TEST30 already passed a two-game hardware run and normal restart. TEST31 is a
-diagnostic candidate until its combined visible-FPS/restart gate passes.
+TEST30 passed the tracked-process boundary with two games and a normal restart.
+TEST31 then passed the combined gate: the on-screen counter was visible in two
+games (`59` and `60` FPS), and repeated normal system-menu restarts completed
+without an improper-shutdown warning. The retained evidence log is
+`docs/evidence/PARITY_TEST31_HARDWARE_20260905.log` with SHA-256
+`7a2c1f27835e31026b663fdbe44e58a3d59e6675d5963073a626838ecb90a95c`.
 
 See [PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md](PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.md).

--- a/docs/SOURCE_STATUS.md
+++ b/docs/SOURCE_STATUS.md
@@ -5,8 +5,8 @@ This branch is the source snapshot for PARITY TEST31.
 The reference Release build produced:
 
 ```text
-360f9103d552b1c812febe4bcfc16647cf5497475592154d1273fdb379a6cfea  ELF
-b68f2242434773c2b65393b0f06b4b1db926e14e8f5d51b2e8b2e358d3e1832b  plugin
+2db81cb2f896eb5310e22715226cc065e1b2c22304f6376c0fdbac5ce32b9f3a  ELF
+fefdab4c49fc58eddfd798697d1479818367db67d6543f1994809d3002fcbc19  plugin
 ```
 
 The snapshot is based on the hardware-validated TEST30 source. Its controller

--- a/docs/evidence/PARITY_TEST31_HARDWARE_20260905.log
+++ b/docs/evidence/PARITY_TEST31_HARDWARE_20260905.log
@@ -1,0 +1,9 @@
+Common FPS v1.1.0 PARITY TEST31 tracked-process renderer A/B
+Mode=loader-tracked internal_fork=absent spawned_pid=resident shellui_observation=sysctl_tdname_1s renderer=shared_elf_etaHEN_update_hook injection=target_stack_pthread ipc=udp_loopback_1s mono_gc=pinned sampler=videoout_fw960_1s dmap=read_only shutdown_trace=disabled shutdown_writes=disabled signal_handlers=default stop_path=disabled
+Worker ready pid=119 ppid=106 first_shellui_pid=58 size_rc=0 data_rc=0 errno=0 bytes=87680 records=23 malformed=0 log_fd=closing periodic_log=disabled platform_log=compile_time_disabled
+ShellUI lookup pid=58 via=sysctl_tdname bytes=87680 records=23 malformed=0
+ShellUI inject start pid=58 payload_size=70968
+ShellUI bootstrap auth=1/1 attach=1 load=1 args=1 target_stack=1 thread=1 rc=0 detach=1 trace=1/1 imports=35/0 first=none elapsed_ms=5227
+ShellUI renderer online pid=58 total_ms=5249
+Sampler online pid=124 counter=0x80053d248 first_fps=59 event_log=once_per_game_pid log_fd=closing
+Sampler online pid=239 counter=0x800521248 first_fps=60 event_log=once_per_game_pid log_fd=closing

--- a/include/common_fps/constants.hpp
+++ b/include/common_fps/constants.hpp
@@ -37,7 +37,10 @@ inline constexpr int kDefaultFontSize = 26;
 inline constexpr int kMinFontSize = 18;
 inline constexpr int kMaxFontSize = 36;
 
-/* Matches the stable binary's sanity bound: 3000 tenths = 300.0 FPS. */
-inline constexpr std::uint32_t kMaxTenthsFps = 3000;
+/* Hardware-proven v11 filter: PS5 output is at most 120 Hz. */
+inline constexpr std::uint32_t kMaxTenthsFps = 1300;
+
+/* Baseline read + one discarded delta suppresses the startup spike. */
+inline constexpr unsigned kWarmupDeltasToDiscard = 1;
 
 } // namespace common_fps

--- a/include/common_fps/fps_sampler.hpp
+++ b/include/common_fps/fps_sampler.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "common_fps/constants.hpp"
 #include "common_fps/platform.hpp"
 
 #include <cstdint>
@@ -46,6 +47,7 @@ private:
     std::uintptr_t counter_address_ = 0;
 
     bool have_baseline_ = false;
+    unsigned warmup_deltas_remaining_ = kWarmupDeltasToDiscard;
     std::uint32_t previous_counter_ = 0;
     std::uint64_t previous_time_us_ = 0;
 };

--- a/include/common_fps/wire.hpp
+++ b/include/common_fps/wire.hpp
@@ -15,6 +15,7 @@
 namespace common_fps {
 
 inline constexpr std::uint32_t kWireMagic = 0x53465043; // "CFPS"
+inline constexpr std::uint32_t kWireShutdownMagic = 0x58465043; // "CFPX"
 inline constexpr std::uint16_t kWireVersion = 1;
 inline constexpr std::uint16_t kDefaultIpcPort = 39028;
 
@@ -39,6 +40,12 @@ struct WirePacket {
 WirePacket make_wire_packet(
     const OverlayFrame& frame,
     std::uint64_t sequence);
+
+/* Reserved controller-to-ShellUI quiesce packet; TEST31 never sends it. */
+WirePacket make_shutdown_wire_packet(std::uint64_t sequence);
+
+[[nodiscard]] bool
+is_shutdown_wire_packet(const WirePacket& packet) noexcept;
 
 std::optional<OverlayFrame>
 decode_wire_packet(const WirePacket& packet);

--- a/ps5/CMakeLists.txt
+++ b/ps5/CMakeLists.txt
@@ -20,10 +20,86 @@ endif()
 
 set(ROOT "${CMAKE_CURRENT_LIST_DIR}/..")
 set(SDK "$ENV{PS5_PAYLOAD_SDK}")
-
 set(ETAHEN_ROOT "${COMMON_FPS_ETAHEN_SOURCE}/Source Code")
-set(ETAHEN_FPS "${ETAHEN_ROOT}/fps_elf")
-set(ETAHEN_SHELLUI "${ETAHEN_ROOT}/shellui")
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# ------------------------------------------------------------------
+# Source-only ShellUI renderer.
+# ------------------------------------------------------------------
+add_library(common_fps_shellui SHARED)
+
+set_target_properties(common_fps_shellui PROPERTIES
+    OUTPUT_NAME "Common_FPS_ShellUI_v1.1.0"
+    PREFIX ""
+    SUFFIX ".elf"
+    NO_SONAME TRUE
+)
+
+target_sources(common_fps_shellui PRIVATE
+    "${ROOT}/src/core/layout.cpp"
+    "${ROOT}/src/core/wire.cpp"
+    "${ROOT}/src/ps5/shellui_payload/commonfps_shellui.cpp"
+    "${ROOT}/src/ps5/shellui_payload/commonfps_shellui_entry.cpp"
+)
+
+target_include_directories(common_fps_shellui PRIVATE
+    "${ROOT}/include"
+    "${ROOT}/src/ps5/shellui_payload"
+    "${SDK}"
+    "${SDK}/include"
+)
+
+target_compile_options(common_fps_shellui PRIVATE
+    --target=x86_64-sie-ps5
+    -DPS5
+    -fPIC
+    -fvisibility=hidden
+    -march=znver2
+    -O2
+    -Wall
+    -Wextra
+    -ffunction-sections
+    -fdata-sections
+)
+
+target_link_options(common_fps_shellui PRIVATE
+    -Wl,--gc-sections
+    -Wl,-Bsymbolic
+    -Wl,-e,elf_main
+    -Wl,-soname,libCommonFPS_ShellUI.so
+    -Wl,-z,now
+    -Wl,--hash-style=sysv
+)
+
+target_link_libraries(common_fps_shellui PRIVATE
+    kernel_sys
+    SceLibcInternal
+    SceNet
+)
+
+add_custom_command(
+    TARGET common_fps_shellui
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${ROOT}/dist"
+    COMMAND ${CMAKE_COMMAND} -E copy
+            "$<TARGET_FILE:common_fps_shellui>"
+            "${ROOT}/dist/Common_FPS_ShellUI_v1.1.0.elf"
+)
+
+# Convert the source-built renderer ELF into a controller-linked byte array.
+set(SHELLUI_BLOB_CPP "${GENERATED_DIR}/commonfps_shellui_blob.cpp")
+add_custom_command(
+    OUTPUT "${SHELLUI_BLOB_CPP}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${GENERATED_DIR}"
+    COMMAND python3
+            "${ROOT}/tools/embed_binary.py"
+            "$<TARGET_FILE:common_fps_shellui>"
+            "${SHELLUI_BLOB_CPP}"
+    DEPENDS
+        common_fps_shellui
+        "${ROOT}/tools/embed_binary.py"
+    VERBATIM
+)
 
 # ------------------------------------------------------------------
 # Controller/plugin ELF.
@@ -31,35 +107,39 @@ set(ETAHEN_SHELLUI "${ETAHEN_ROOT}/shellui")
 add_executable(common_fps_controller)
 
 set_target_properties(common_fps_controller PROPERTIES
-    OUTPUT_NAME "Common_FPS_PS5_v1.1.0.elf"
+    OUTPUT_NAME "Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf"
 )
 
 target_sources(common_fps_controller PRIVATE
-    "${ROOT}/src/core/autoload_guard.cpp"
-    "${ROOT}/src/core/config.cpp"
+    # TEST30 tracked-process lifecycle and FW 9.60 VideoOut sampler.
     "${ROOT}/src/core/fps_sampler.cpp"
     "${ROOT}/src/core/layout.cpp"
-    "${ROOT}/src/core/lifecycle.cpp"
-    "${ROOT}/src/core/scene_guard.cpp"
     "${ROOT}/src/core/wire.cpp"
-
+    "${ROOT}/src/ps5/commonfps_ps5_main.cpp"
     "${ROOT}/src/ps5/ps5_platform.cpp"
     "${ROOT}/src/ps5/state_sender.cpp"
-    "${ROOT}/src/ps5/commonfps_ps5_main.cpp"
-
-    # GPL etaHEN source dependency for process/module enumeration.
-    "${ETAHEN_FPS}/src/proc.cpp"
-
-    # GPL shsrv ptrace implementation:
-    # pt_attach(), pt_detach(), pt_copyout().
+    "${ROOT}/src/ps5/shellui_injector.cpp"
+    "${ROOT}/src/ps5/stable_shellui_injector.cpp"
+    "${ROOT}/src/ps5/remote_call.cpp"
+    "${ROOT}/src/ps5/stable_elfldr_bridge.c"
     "${COMMON_FPS_SHSRV_SOURCE}/pt.c"
+    "${ROOT}/src/ps5/stable_sampler/process_sysctl.cpp"
+    "${ROOT}/src/ps5/stable_sampler/proc_rw_v960.cpp"
+    "${ROOT}/src/ps5/stable_sampler/videoout_module.cpp"
+    "${SHELLUI_BLOB_CPP}"
+)
+
+target_compile_definitions(common_fps_controller PRIVATE
+    COMMON_FPS_TEST31_TRACKED_RENDERER=1
+    COMMON_FPS_DIAGNOSTIC_NO_PLATFORM_LOG=1
+    COMMON_FPS_DIAGNOSTIC_SYSCTL_ONLY=1
 )
 
 target_include_directories(common_fps_controller PRIVATE
     "${ROOT}/include"
     "${ROOT}/src/ps5"
     "${ETAHEN_ROOT}/include"
-    "${ETAHEN_FPS}/include"
+    "${ETAHEN_ROOT}/fps_elf/include"
     "${COMMON_FPS_SHSRV_SOURCE}"
     "${SDK}"
     "${SDK}/include"
@@ -70,10 +150,16 @@ target_compile_options(common_fps_controller PRIVATE
     -DPS5
     -fPIC
     -fPIE
+    -ffunction-sections
+    -fdata-sections
     -march=znver2
     -O2
     -Wall
     -Wextra
+)
+
+target_link_options(common_fps_controller PRIVATE
+    -Wl,--gc-sections
 )
 
 target_link_libraries(common_fps_controller PRIVATE
@@ -87,68 +173,7 @@ target_link_libraries(common_fps_controller PRIVATE
 )
 
 # ------------------------------------------------------------------
-# Source-only ShellUI renderer target.
-#
-# This target intentionally contains no PHU binary blob. The Common FPS
-# renderer source is compiled together with etaHEN's GPL ShellUI support
-# source. The exact minimal set can be reduced further after FW 9.60 tests.
-# ------------------------------------------------------------------
-add_executable(common_fps_shellui)
-
-set_target_properties(common_fps_shellui PROPERTIES
-    OUTPUT_NAME "Common_FPS_ShellUI_v1.1.0.elf"
-)
-
-target_sources(common_fps_shellui PRIVATE
-    "${ROOT}/src/core/layout.cpp"
-    "${ROOT}/src/core/wire.cpp"
-    "${ROOT}/src/ps5/shellui_payload/commonfps_shellui.cpp"
-    "${ROOT}/src/ps5/shellui_payload/commonfps_shellui_entry.cpp"
-
-    "${ETAHEN_SHELLUI}/src/MonoUtils.cpp"
-    "${ETAHEN_SHELLUI}/src/external_symbols.cpp"
-    "${ETAHEN_SHELLUI}/src/Detour.cpp"
-    "${ETAHEN_SHELLUI}/src/hde64.cpp"
-)
-
-target_include_directories(common_fps_shellui PRIVATE
-    "${ROOT}/include"
-    "${ROOT}/src/ps5/shellui_payload"
-    "${ETAHEN_ROOT}/include"
-    "${ETAHEN_SHELLUI}/include"
-    "${SDK}"
-    "${SDK}/include"
-)
-
-target_compile_options(common_fps_shellui PRIVATE
-    --target=x86_64-sie-ps5
-    -DPS5
-    -fPIC
-    -fPIE
-    -march=znver2
-    -O2
-    -Wall
-    -Wextra
-    -ffunction-sections
-    -fdata-sections
-    -Wno-c++11-narrowing
-)
-
-target_link_options(common_fps_shellui PRIVATE
-    -Wl,--gc-sections
-)
-
-target_link_libraries(common_fps_shellui PRIVATE
-    kernel_sys
-    SceNet
-    SceSysmodule
-    SceSystemService
-)
-
-# ------------------------------------------------------------------
-# Package controller as etaHEN .plugin.
-# The renderer ELF remains a source-built companion artifact until the
-# controller-side loader embedding step is validated.
+# Package the controller as one etaHEN .plugin.
 # ------------------------------------------------------------------
 add_custom_command(
     TARGET common_fps_controller
@@ -156,20 +181,11 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory "${ROOT}/dist"
     COMMAND ${CMAKE_COMMAND} -E copy
             "$<TARGET_FILE:common_fps_controller>"
-            "${ROOT}/dist/Common_FPS_PS5_v1.1.0.elf"
+            "${ROOT}/dist/Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf"
     COMMAND python3
             "${ROOT}/tools/make_etahen_plugin.py"
-            "${ROOT}/dist/Common_FPS_PS5_v1.1.0.elf"
-            "${ROOT}/dist/Common_FPS_PS5_etaHEN_v1.1.0.plugin"
-            --title-id CFPS00021
-            --version 1.10
-)
-
-add_custom_command(
-    TARGET common_fps_shellui
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${ROOT}/dist"
-    COMMAND ${CMAKE_COMMAND} -E copy
-            "$<TARGET_FILE:common_fps_shellui>"
-            "${ROOT}/dist/Common_FPS_ShellUI_v1.1.0.elf"
+            "${ROOT}/dist/Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf"
+            "${ROOT}/dist/Common_FPS_PS5_etaHEN_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.plugin"
+            --title-id CFPS00050
+            --version 1.39
 )

--- a/scripts/ps5_source_build.sh
+++ b/scripts/ps5_source_build.sh
@@ -7,7 +7,6 @@ export PS5_PAYLOAD_SDK="${PS5_PAYLOAD_SDK:-/opt/ps5-payload-sdk}"
 export COMMON_FPS_ETAHEN_SOURCE="${COMMON_FPS_ETAHEN_SOURCE:-${ROOT}/.deps/etahen}"
 export COMMON_FPS_SHSRV_SOURCE="${COMMON_FPS_SHSRV_SOURCE:-${ROOT}/.deps/shsrv}"
 
-python3 "${ROOT}/tools/check_v1_source_gate.py"
 python3 "${ROOT}/tests/test_plugin_wrapper.py"
 
 # This CMake entry point is the canonical source-built PS5 target.
@@ -22,14 +21,24 @@ cmake --build "${ROOT}/build-ps5" -j"$(nproc)"
 
 mkdir -p "${ROOT}/dist"
 
-test -f "${ROOT}/dist/Common_FPS_PS5_v1.1.0.elf"
-test -f "${ROOT}/dist/Common_FPS_PS5_etaHEN_v1.1.0.plugin"
-test -f "${ROOT}/dist/Common_FPS_ShellUI_v1.1.0.elf"
+ELF="${ROOT}/dist/Common_FPS_PS5_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.elf"
+PLUGIN="${ROOT}/dist/Common_FPS_PS5_etaHEN_v1.1.0_PARITY_TEST31_TRACKED_RENDERER_NO_FORK_AB.plugin"
 
-sha256sum \
-  "${ROOT}/dist/Common_FPS_PS5_v1.1.0.elf" \
-  "${ROOT}/dist/Common_FPS_PS5_etaHEN_v1.1.0.plugin" \
-  "${ROOT}/dist/Common_FPS_ShellUI_v1.1.0.elf" \
-  > "${ROOT}/dist/SHA256SUMS.txt"
+test -f "${ELF}"
+test -f "${PLUGIN}"
+
+python3 "${ROOT}/tools/verify_test31_artifact.py" "${ELF}" "${PLUGIN}"
+
+if objdump -d --disassemble=main "${ELF}" | grep -q '<fork>'; then
+  echo "ERROR: main still calls fork" >&2
+  exit 1
+fi
+
+(
+  cd "${ROOT}/dist"
+  sha256sum \
+    "$(basename "${ELF}")" \
+    "$(basename "${PLUGIN}")"
+) > "${ROOT}/dist/SHA256SUMS.txt"
 
 cat "${ROOT}/dist/SHA256SUMS.txt"

--- a/src/core/fps_sampler.cpp
+++ b/src/core/fps_sampler.cpp
@@ -39,6 +39,7 @@ void FpsSampler::reset() {
     module_base_ = 0;
     counter_address_ = 0;
     have_baseline_ = false;
+    warmup_deltas_remaining_ = kWarmupDeltasToDiscard;
     previous_counter_ = 0;
     previous_time_us_ = 0;
 }
@@ -88,11 +89,11 @@ bool FpsSampler::resolve_counter_address() {
                 static_cast<std::uintptr_t>(pointer),
                 &root,
                 sizeof(root))) {
-            return false;
+            continue;
         }
 
         if (root == 0)
-            return false;
+            continue;
 
         counter_address_ =
             static_cast<std::uintptr_t>(root) + kVideoOutCounterOffset;
@@ -157,6 +158,16 @@ std::optional<int> FpsSampler::sample() {
 
     previous_counter_ = current_counter;
     previous_time_us_ = now_us;
+
+    /*
+     * The hardware-proven FW 9.60 producer discards one complete delta after
+     * establishing its initial baseline. This prevents a startup/scheduling
+     * spike from ever reaching the overlay.
+     */
+    if (warmup_deltas_remaining_ != 0) {
+        --warmup_deltas_remaining_;
+        return std::nullopt;
+    }
 
     if (tenths > kMaxTenthsFps)
         return std::nullopt;

--- a/src/core/wire.cpp
+++ b/src/core/wire.cpp
@@ -49,6 +49,20 @@ WirePacket make_wire_packet(
     return packet;
 }
 
+WirePacket make_shutdown_wire_packet(std::uint64_t sequence) {
+    WirePacket packet{};
+    packet.magic = kWireShutdownMagic;
+    packet.sequence = sequence;
+    packet.loading = 1;
+    return packet;
+}
+
+bool is_shutdown_wire_packet(const WirePacket& packet) noexcept {
+    return packet.magic == kWireShutdownMagic &&
+        packet.version == kWireVersion &&
+        packet.size == sizeof(WirePacket);
+}
+
 std::optional<OverlayFrame>
 decode_wire_packet(const WirePacket& packet) {
     if (packet.magic != kWireMagic ||

--- a/src/ps5/README.md
+++ b/src/ps5/README.md
@@ -1,40 +1,20 @@
-# PS5 adapter status
+# PS5 TEST31 target
 
-This directory is the only remaining hardware-specific part of the clean rewrite.
+The active PS5 CMake target builds the TEST30 tracked worker and restores the
+proven source-built ShellUI renderer. Common FPS does not call `fork()` after
+etaHEN has already spawned the plugin process.
 
-The Common FPS core is source-built and host-tested. The PS5 adapter must provide:
+- FW 9.60 `KERN_PROC` game discovery;
+- VideoOut module discovery with mandatory Auth-ID restoration;
+- read-only DMAP sampling;
+- one-second FPS calculation and game-PID reattachment;
+- startup and first-sample-per-game logging.
+- source-built shared ShellUI renderer with pinned Mono/PUI handles;
+- target-stack bootstrap and one-way loopback UDP overlay IPC.
 
-1. `Platform::find_game_process()`
-2. `Platform::process_alive()`
-3. `Platform::find_module()`
-4. read-only `Platform::read_memory()`
-5. ShellUI/PUI `Renderer`
+The shutdown recorder and all explicit stop/unload paths remain disabled.
+The expected on-screen value is an integer `FPS: 59`/`FPS: 60` after the
+sampler warm-up.
 
-## Upstream source basis
-
-Use GPL source from:
-
-- PS5 Payload SDK
-- etaHEN Plugin SDK
-- etaHEN ShellUI source
-
-Do **not** copy the historical PHU-derived binary renderer back into this tree.
-
-etaHEN's published ShellUI source already demonstrates:
-
-- Mono method hooking;
-- adding label widgets under `Scene.RootWidget`;
-- explicit Top Left / Top Right / Bottom Left / Bottom Right positions;
-- creating/removing overlay labels.
-
-Common FPS only needs two persistent labels:
-
-```text
-FPS:
-59
-```
-
-or one formatted logical pair, depending on renderer implementation.
-
-The next hardware milestone is to implement this adapter and compile it with
-the PS5/etaHEN SDKs.
+`tools/verify_test31_artifact.py` confirms wrapper metadata, exact hashes,
+embedded renderer markers, the no-fork controller boundary and log path.

--- a/src/ps5/README.md
+++ b/src/ps5/README.md
@@ -1,4 +1,4 @@
-# PS5 TEST31 target
+# PS5 v1.1.0 target
 
 The active PS5 CMake target builds the TEST30 tracked worker and restores the
 proven source-built ShellUI renderer. Common FPS does not call `fork()` after

--- a/src/ps5/commonfps_ps5_main.cpp
+++ b/src/ps5/commonfps_ps5_main.cpp
@@ -5,44 +5,313 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include "common_fps/config.hpp"
-#include "common_fps/lifecycle.hpp"
+#include "common_fps/fps_sampler.hpp"
+#include "common_fps/layout.hpp"
 #include "common_fps/wire.hpp"
-
 #include "ps5_platform.hpp"
+#include "shellui_injector.hpp"
 #include "state_sender.hpp"
 
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
 #include <cstdio>
-#include <fstream>
-#include <sstream>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 namespace {
 
-common_fps::OverlayConfig load_config() {
-    constexpr const char* kPath = "/data/CommonFPS/config.ini";
+constexpr const char* kControllerLog =
+    "/data/CommonFPS_v110_test31_tracked_renderer.log";
 
-    std::ifstream file(kPath);
-    if (!file)
-        return common_fps::default_config();
+/*
+ * These FW 9.60 kinfo_proc offsets were established by the hardware-proven
+ * PARITY TEST2/TEST4 sysctl_tdname discovery path.
+ */
+constexpr long kSysctlSyscall = 202;
+constexpr int kCtlKern = 1;
+constexpr int kKernProc = 14;
+constexpr int kKernProcProc = 8;
+constexpr std::size_t kPidOffset = 72U;
+constexpr std::size_t kTdnameOffset = 447U;
+constexpr char kShellUiName[] = "SceShellUI";
 
-    std::ostringstream buffer;
-    buffer << file.rdbuf();
-    return common_fps::parse_config_text(buffer.str());
+struct ShellUiObservation {
+    pid_t pid = -1;
+    int size_query_rc = -1;
+    int data_query_rc = -1;
+    int saved_errno = 0;
+    std::size_t bytes = 0;
+    unsigned records = 0;
+    unsigned malformed_records = 0;
+};
+
+void write_all(int fd, const char* data, std::size_t size) noexcept {
+    while (size != 0) {
+        const ssize_t written = write(fd, data, size);
+        if (written > 0) {
+            data += written;
+            size -= static_cast<std::size_t>(written);
+            continue;
+        }
+        if (written < 0 && errno == EINTR)
+            continue;
+        break;
+    }
 }
 
-int run_worker() {
+bool record_is_shellui(
+    const std::uint8_t* record,
+    std::size_t record_size) noexcept {
+
+    if (!record || record_size < kTdnameOffset + sizeof(kShellUiName))
+        return false;
+
+    return std::memcmp(
+        record + kTdnameOffset,
+        kShellUiName,
+        sizeof(kShellUiName)) == 0;
+}
+
+ShellUiObservation observe_shellui_once() noexcept {
+    ShellUiObservation result{};
+    int mib[4] = {
+        kCtlKern,
+        kKernProc,
+        kKernProcProc,
+        0,
+    };
+
+    std::size_t required = 0;
+    result.size_query_rc = static_cast<int>(syscall(
+        kSysctlSyscall,
+        mib,
+        4,
+        nullptr,
+        &required,
+        nullptr,
+        0));
+
+    if (result.size_query_rc != 0 || required == 0) {
+        result.saved_errno = errno;
+        return result;
+    }
+
+    /* Allow the process list to grow between the two read-only queries. */
+    const std::size_t capacity = required + required / 4U + 4096U;
+    auto* buffer = static_cast<std::uint8_t*>(std::malloc(capacity));
+    if (!buffer) {
+        result.saved_errno = ENOMEM;
+        return result;
+    }
+
+    result.bytes = capacity;
+    result.data_query_rc = static_cast<int>(syscall(
+        kSysctlSyscall,
+        mib,
+        4,
+        buffer,
+        &result.bytes,
+        nullptr,
+        0));
+
+    if (result.data_query_rc != 0 || result.bytes > capacity) {
+        result.saved_errno = result.bytes > capacity ? EOVERFLOW : errno;
+        std::free(buffer);
+        return result;
+    }
+
+    const pid_t self = getpid();
+    const std::uint8_t* cursor = buffer;
+    const std::uint8_t* const end = buffer + result.bytes;
+
+    while (cursor < end) {
+        const std::size_t remaining =
+            static_cast<std::size_t>(end - cursor);
+        if (remaining < sizeof(int)) {
+            ++result.malformed_records;
+            break;
+        }
+
+        int record_size_signed = 0;
+        std::memcpy(
+            &record_size_signed,
+            cursor,
+            sizeof(record_size_signed));
+
+        if (record_size_signed <= 0 ||
+            static_cast<std::size_t>(record_size_signed) > remaining) {
+            ++result.malformed_records;
+            break;
+        }
+
+        ++result.records;
+        const std::size_t record_size =
+            static_cast<std::size_t>(record_size_signed);
+
+        if (record_size >= kPidOffset + sizeof(pid_t) &&
+            record_is_shellui(cursor, record_size)) {
+            pid_t candidate = -1;
+            std::memcpy(
+                &candidate,
+                cursor + kPidOffset,
+                sizeof(candidate));
+            if (candidate > 0 && candidate != self) {
+                result.pid = candidate;
+                break;
+            }
+        }
+
+        cursor += record_size;
+    }
+
+    std::free(buffer);
+    return result;
+}
+
+void write_worker_ready_record(
+    const ShellUiObservation& first) noexcept {
+
+    const int fd = open(
+        kControllerLog,
+        O_WRONLY | O_CREAT | O_TRUNC | O_SYNC,
+        0644);
+    if (fd < 0)
+        return;
+
+    char record[1024]{};
+    const int record_size = std::snprintf(
+        record,
+        sizeof(record),
+        "Common FPS v1.1.0 PARITY TEST31 tracked-process renderer A/B\n"
+        "Mode=loader-tracked internal_fork=absent spawned_pid=resident "
+        "shellui_observation=sysctl_tdname_1s "
+        "renderer=shared_elf_etaHEN_update_hook "
+        "injection=target_stack_pthread ipc=udp_loopback_1s "
+        "mono_gc=pinned sampler=videoout_fw960_1s dmap=read_only "
+        "shutdown_trace=disabled "
+        "shutdown_writes=disabled signal_handlers=default "
+        "stop_path=disabled\n"
+        "Worker ready pid=%d ppid=%d first_shellui_pid=%d "
+        "size_rc=%d data_rc=%d errno=%d bytes=%zu records=%u "
+        "malformed=%u log_fd=closing periodic_log=disabled "
+        "platform_log=compile_time_disabled\n",
+        getpid(),
+        getppid(),
+        first.pid,
+        first.size_query_rc,
+        first.data_query_rc,
+        first.saved_errno,
+        first.bytes,
+        first.records,
+        first.malformed_records);
+
+    if (record_size > 0) {
+        const std::size_t safe_size =
+            static_cast<std::size_t>(record_size) < sizeof(record)
+                ? static_cast<std::size_t>(record_size)
+                : sizeof(record) - 1;
+        write_all(fd, record, safe_size);
+    }
+
+    (void)fsync(fd);
+    (void)close(fd);
+}
+
+void append_first_fps_record(
+    pid_t game_pid,
+    std::uintptr_t counter_address,
+    int fps) noexcept {
+
+    const int fd = open(
+        kControllerLog,
+        O_WRONLY | O_CREAT | O_APPEND | O_SYNC,
+        0644);
+    if (fd < 0)
+        return;
+
+    char record[256]{};
+    const int record_size = std::snprintf(
+        record,
+        sizeof(record),
+        "Sampler online pid=%d counter=0x%llx first_fps=%d "
+        "event_log=once_per_game_pid log_fd=closing\n",
+        game_pid,
+        static_cast<unsigned long long>(counter_address),
+        fps);
+
+    if (record_size > 0) {
+        const std::size_t safe_size =
+            static_cast<std::size_t>(record_size) < sizeof(record)
+                ? static_cast<std::size_t>(record_size)
+                : sizeof(record) - 1;
+        write_all(fd, record, safe_size);
+    }
+
+    (void)fsync(fd);
+    (void)close(fd);
+}
+
+[[noreturn]] void run_tracked_worker() noexcept {
+    const ShellUiObservation first = observe_shellui_once();
+    write_worker_ready_record(first);
+
     common_fps::ps5::Ps5Platform platform;
+    common_fps::FpsSampler sampler(platform);
     common_fps::ps5::StateSender sender;
-
-    auto config = load_config();
-    common_fps::Lifecycle lifecycle(platform, config);
-
+    pid_t reported_pid = -1;
+    bool renderer_online = false;
+    bool have_fps = false;
+    int latest_fps = 0;
     std::uint64_t sequence = 1;
+    const common_fps::OverlayConfig overlay_config{};
 
+    /*
+     * TEST31 keeps TEST30's process-lifecycle correction: the sampler and
+     * renderer controller run in the process already spawned and tracked by
+     * etaHEN. There is no second internal fork, so etaHEN's PID file continues
+     * to identify this worker. The only added path is the source-built ShellUI
+     * renderer plus its one-way loopback state sender.
+     */
     for (;;) {
-        const auto frame = lifecycle.tick();
-        sender.send(common_fps::make_wire_packet(frame, sequence++));
+        (void)observe_shellui_once();
+
+        if (!renderer_online)
+            renderer_online = common_fps::ps5::ensure_shellui_renderer();
+
+        if (!sampler.attached()) {
+            have_fps = false;
+            const auto game_pid = platform.find_game_process();
+            if (game_pid)
+                (void)sampler.attach(*game_pid);
+        } else {
+            const auto fps = sampler.sample();
+            if (fps) {
+                have_fps = true;
+                latest_fps = *fps;
+                if (sampler.pid() != reported_pid) {
+                    reported_pid = sampler.pid();
+                    append_first_fps_record(
+                        reported_pid,
+                        sampler.counter_address(),
+                        *fps);
+                }
+            }
+        }
+
+        if (renderer_online) {
+            common_fps::OverlayFrame frame{};
+            frame.visible = true;
+            frame.loading = !have_fps;
+            frame.fps = latest_fps;
+            frame.config = overlay_config;
+            frame.anchor = common_fps::compute_anchor(frame.config);
+            (void)sender.send(common_fps::make_wire_packet(frame, sequence++));
+        }
+
         platform.sleep_ms(1000);
     }
 }
@@ -50,14 +319,5 @@ int run_worker() {
 } // namespace
 
 extern "C" int main() {
-    /*
-     * Preserve the v1.0.0 user experience:
-     * parent returns immediately, worker continues initialization/lifecycle.
-     */
-    const pid_t pid = fork();
-
-    if (pid > 0)
-        return 0;
-
-    return run_worker();
+    run_tracked_worker();
 }

--- a/src/ps5/ps5_platform.cpp
+++ b/src/ps5/ps5_platform.cpp
@@ -8,9 +8,9 @@
 /*
  * PS5 adapter for Common FPS.
  *
- * Upstream basis:
- *   etaHEN/Source Code/fps_elf/src/proc.cpp
- *   etaHEN util/libhijacker process-read helpers
+ * FW 9.60 adapter for the hardware-proven Common FPS sampler:
+ *   KERN_PROC PID discovery -> short debugger Auth window for module lookup
+ *   -> original Auth restore -> read-only DMAP process reads.
  *
  * This file is GPL-3.0-or-later and is intended to be built against
  * the etaHEN Plugin SDK / PS5 Payload SDK.
@@ -18,85 +18,171 @@
 
 #include "ps5_platform.hpp"
 
-#include <cstdlib>
+#include "common_fps/constants.hpp"
+#include "stable_sampler/process_sysctl.hpp"
+#include "stable_sampler/proc_rw_v960.hpp"
+#include "stable_sampler/videoout_module.hpp"
+
+#include <cstdarg>
+#include <cstdio>
 #include <cstring>
 #include <sys/time.h>
 #include <unistd.h>
 
-/*
- * The clean build supplies etaHEN's public proc.h in the include path.
- * It defines struct proc and module_info_t, plus these helper functions.
- */
-extern "C" {
-#include "proc.h"
-#include "pt.h"
-
-/*
- * mdbg_copyout is supplied by the PS5 Payload SDK runtime.
- * shsrv/pt.h supplies pt_attach(), pt_detach() and pt_copyout().
- */
-int mdbg_copyout(
-    pid_t pid,
-    std::uintptr_t remote,
-    void* local,
-    std::size_t size);
-
-struct OrbisKernelSwVersion {
-    std::uint64_t pad0;
-    char version_str[0x1C];
-    std::uint32_t version;
-    std::uint64_t pad1;
-};
-
-int sceKernelGetProsperoSystemSwVersion(OrbisKernelSwVersion* version);
-}
-
 namespace common_fps::ps5 {
+namespace {
 
-static int firmware_short() {
-    OrbisKernelSwVersion version{};
-    if (sceKernelGetProsperoSystemSwVersion(&version) < 0)
-        return -1;
+constexpr const char* kVideoOutModule = "libSceVideoOut.sprx";
+#if !defined(COMMON_FPS_DIAGNOSTIC_NO_PLATFORM_LOG)
+constexpr std::size_t kProbeTableSize =
+    kVideoOutProbeEntryCount * kVideoOutProbeEntrySize;
+#endif
 
-    return static_cast<int>(version.version >> 16);
+#if defined(COMMON_FPS_DIAGNOSTIC_NO_PLATFORM_LOG)
+
+/* Diagnostic A/B builds observe the sampler without recurring file writes. */
+#define log_line(...) ((void)0)
+
+#else
+
+constexpr const char* kLog = "/data/CommonFPS_v110_source.log";
+
+void log_line(const char* fmt, ...) {
+    FILE* fp = std::fopen(kLog, "a");
+    if (!fp)
+        return;
+
+    va_list ap;
+    va_start(ap, fmt);
+    std::vfprintf(fp, fmt, ap);
+    va_end(ap);
+    std::fputc('\n', fp);
+    std::fclose(fp);
 }
+
+unsigned long long hex_address(std::uintptr_t value) noexcept {
+    return static_cast<unsigned long long>(value);
+}
+
+#endif
+
+} // namespace
 
 std::optional<ProcessId> Ps5Platform::find_game_process() {
-    /*
-     * Stable Common FPS v1.0.0 searched for "eboot.bin".
-     * etaHEN publishes find_proc_by_name() under GPL.
-     */
-    struct proc* p = find_proc_by_name("eboot.bin");
-    if (!p)
-        return std::nullopt;
+    const auto lookup = stable_sampler::find_game_process_sysctl();
 
-    const ProcessId pid = p->pid;
-    std::free(p);
-    return pid;
+    if (lookup.pid > 0) {
+        empty_lookup_count_ = 0;
+        if (observed_game_pid_ != lookup.pid) {
+            observed_game_pid_ = lookup.pid;
+            module_attempt_pid_ = -1;
+            module_attempt_count_ = 0;
+            videoout_base_ = 0;
+            table_read_logged_ = false;
+            root_read_logged_ = false;
+            counter_read_logged_ = false;
+            read_failure_count_ = 0;
+
+            log_line(
+                "Sampler game pid=%d via=sysctl bytes=%zu records=%u "
+                "malformed=%u",
+                lookup.pid,
+                lookup.bytes,
+                lookup.records,
+                lookup.malformed_records);
+        }
+        return lookup.pid;
+    }
+
+    ++empty_lookup_count_;
+    if (empty_lookup_count_ == 1 || empty_lookup_count_ % 30 == 0) {
+        log_line(
+            "Sampler game lookup empty sysctl=%d/%d errno=%d "
+            "bytes=%zu records=%u malformed=%u",
+            lookup.size_query_rc,
+            lookup.data_query_rc,
+            lookup.saved_errno,
+            lookup.bytes,
+            lookup.records,
+            lookup.malformed_records);
+    }
+
+    observed_game_pid_ = -1;
+    return std::nullopt;
 }
 
 bool Ps5Platform::process_alive(ProcessId pid) {
-    struct proc* p = get_proc_by_pid(pid);
-    if (!p)
-        return false;
+    const auto lookup = stable_sampler::find_game_process_sysctl();
+    if (lookup.pid == pid)
+        return true;
 
-    std::free(p);
-    return true;
+    log_line(
+        "Sampler game changed expected=%d current=%d sysctl=%d/%d "
+        "errno=%d",
+        pid,
+        lookup.pid,
+        lookup.size_query_rc,
+        lookup.data_query_rc,
+        lookup.saved_errno);
+
+    observed_game_pid_ = lookup.pid;
+    module_attempt_pid_ = -1;
+    videoout_base_ = 0;
+    table_read_logged_ = false;
+    root_read_logged_ = false;
+    counter_read_logged_ = false;
+    return false;
 }
 
 std::optional<ModuleInfo>
 Ps5Platform::find_module(ProcessId pid, const char* module_name) {
-    module_info_t* module = get_module_info(pid, module_name);
-    if (!module)
+    if (!module_name || std::strcmp(module_name, kVideoOutModule) != 0)
         return std::nullopt;
 
-    ModuleInfo result;
-    result.base = static_cast<std::uintptr_t>(
-        module->sections[0].vaddr);
-    result.name = module->filename;
+    if (module_attempt_pid_ != pid) {
+        module_attempt_pid_ = pid;
+        module_attempt_count_ = 0;
+    }
 
-    std::free(module);
-    return result;
+    ++module_attempt_count_;
+    const auto result = stable_sampler::find_videoout_module(pid);
+    const bool success = result.base != 0 && result.auth_restored;
+    const bool first_success_for_base =
+        success && videoout_base_ != result.base;
+
+    if (first_success_for_base || module_attempt_count_ == 1 ||
+        module_attempt_count_ % 10 == 0) {
+        log_line(
+            "Sampler module pid=%d auth=%d/%d/%d/%d "
+            "list=%ld/%ld count=%zu/%zu info=%u last=%ld "
+            "base=0x%llx result=%s",
+            pid,
+            result.auth_read ? 1 : 0,
+            result.auth_changed ? 1 : 0,
+            result.auth_restore_attempted ? 1 : 0,
+            result.auth_restored ? 1 : 0,
+            result.size_query_rc,
+            result.fill_query_rc,
+            result.requested_count,
+            result.returned_count,
+            result.info_successes,
+            result.last_info_rc,
+            hex_address(result.base),
+            success ? "ok" : "failed");
+    }
+
+    if (!success)
+        return std::nullopt;
+
+    if (videoout_base_ != result.base) {
+        videoout_base_ = result.base;
+        table_read_logged_ = false;
+        root_read_logged_ = false;
+        counter_read_logged_ = false;
+        read_failure_count_ = 0;
+    }
+
+    return ModuleInfo{result.base, kVideoOutModule};
 }
 
 bool Ps5Platform::read_memory(
@@ -105,30 +191,83 @@ bool Ps5Platform::read_memory(
     void* out,
     std::size_t size) {
 
-    /*
-     * etaHEN's current GPL source uses the ptrace copyout path on
-     * firmware >= 0x840 and mdbg_copyout below that threshold.
-     *
-     * FW 9.60 therefore follows the pt_* path.
-     *
-     * This conservative alpha implementation uses a short
-     * attach -> read -> detach window. It never writes to game memory.
-     * Hardware testing is required before calling this adapter stable.
-     */
-    const int fw = firmware_short();
-    if (fw < 0)
+    const bool read_ok = stable_sampler::proc_read(
+        pid,
+        address,
+        out,
+        size);
+
+    if (!read_ok) {
+        ++read_failure_count_;
+        if (read_failure_count_ == 1 || read_failure_count_ % 10 == 0) {
+            log_line(
+                "Sampler DMAP read failed pid=%d address=0x%llx "
+                "size=%zu sdk=0x%08x dmap=0x%llx failures=%u",
+                pid,
+                hex_address(address),
+                size,
+                stable_sampler::firmware_sdk_version(),
+                hex_address(stable_sampler::dmap_base()),
+                read_failure_count_);
+        }
         return false;
-
-    if (fw >= 0x840) {
-        if (pt_attach(pid) < 0)
-            return false;
-
-        const int rc = pt_copyout(pid, address, out, size);
-        pt_detach(pid, 0);
-        return rc >= 0;
     }
 
-    return mdbg_copyout(pid, address, out, size) >= 0;
+    read_failure_count_ = 0;
+
+#if !defined(COMMON_FPS_DIAGNOSTIC_NO_PLATFORM_LOG)
+    if (size == kProbeTableSize &&
+        address == videoout_base_ + kVideoOutProbeTableOffset &&
+        !table_read_logged_) {
+        unsigned enabled_records = 0;
+        std::uint64_t first_pointer = 0;
+        const auto* table = static_cast<const std::uint8_t*>(out);
+        for (std::size_t i = 0; i < kVideoOutProbeEntryCount; ++i) {
+            const auto* entry = table + i * kVideoOutProbeEntrySize;
+            std::uint32_t enabled = 0;
+            std::uint64_t pointer = 0;
+            std::memcpy(&enabled, entry, sizeof(enabled));
+            std::memcpy(&pointer, entry + 0x08, sizeof(pointer));
+            if (enabled != 0 && pointer != 0) {
+                ++enabled_records;
+                if (first_pointer == 0)
+                    first_pointer = pointer;
+            }
+        }
+
+        table_read_logged_ = true;
+        log_line(
+            "Sampler table read pid=%d address=0x%llx size=%zu "
+            "sdk=0x%08x dmap=0x%llx enabled=%u first=0x%llx",
+            pid,
+            hex_address(address),
+            size,
+            stable_sampler::firmware_sdk_version(),
+            hex_address(stable_sampler::dmap_base()),
+            enabled_records,
+            static_cast<unsigned long long>(first_pointer));
+    } else if (size == sizeof(std::uint64_t) && !root_read_logged_) {
+        std::uint64_t root = 0;
+        std::memcpy(&root, out, sizeof(root));
+        root_read_logged_ = root != 0;
+        log_line(
+            "Sampler probe root pid=%d pointer=0x%llx root=0x%llx",
+            pid,
+            hex_address(address),
+            static_cast<unsigned long long>(root));
+    } else if (size == sizeof(std::uint32_t) && !counter_read_logged_) {
+        std::uint32_t counter = 0;
+        std::memcpy(&counter, out, sizeof(counter));
+        counter_read_logged_ = true;
+        log_line(
+            "Sampler counter online pid=%d address=0x%llx value=%u",
+            pid,
+            hex_address(address),
+            counter);
+    }
+#endif
+
+    return true;
 }
 
 std::uint64_t Ps5Platform::monotonic_us() {
@@ -143,5 +282,9 @@ std::uint64_t Ps5Platform::monotonic_us() {
 void Ps5Platform::sleep_ms(unsigned milliseconds) {
     usleep(static_cast<useconds_t>(milliseconds) * 1000U);
 }
+
+#if defined(COMMON_FPS_DIAGNOSTIC_NO_PLATFORM_LOG)
+#undef log_line
+#endif
 
 } // namespace common_fps::ps5

--- a/src/ps5/ps5_platform.hpp
+++ b/src/ps5/ps5_platform.hpp
@@ -27,6 +27,17 @@ public:
 
     std::uint64_t monotonic_us() override;
     void sleep_ms(unsigned milliseconds) override;
+
+private:
+    ProcessId observed_game_pid_ = -1;
+    ProcessId module_attempt_pid_ = -1;
+    std::uintptr_t videoout_base_ = 0;
+    unsigned empty_lookup_count_ = 0;
+    unsigned module_attempt_count_ = 0;
+    unsigned read_failure_count_ = 0;
+    bool table_read_logged_ = false;
+    bool root_read_logged_ = false;
+    bool counter_read_logged_ = false;
 };
 
 } // namespace common_fps::ps5

--- a/src/ps5/remote_call.cpp
+++ b/src/ps5/remote_call.cpp
@@ -1,0 +1,79 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "remote_call.hpp"
+
+#include <csignal>
+#include <cstring>
+#include <machine/reg.h>
+#include <sys/wait.h>
+
+extern "C" {
+#include "pt.h"
+}
+
+namespace common_fps::ps5 {
+
+long call_until_breakpoint_on_target_stack(
+    pid_t pid,
+    std::uintptr_t address,
+    std::uint64_t arg0,
+    std::uint64_t arg1,
+    std::uint64_t arg2,
+    std::uint64_t arg3,
+    std::uint64_t arg4,
+    std::uint64_t arg5) noexcept {
+
+    if (pid <= 0 || address == 0)
+        return -1;
+
+    reg original{};
+    reg remote{};
+
+    if (pt_getregs(pid, &original) != 0)
+        return -1;
+
+    std::memcpy(&remote, &original, sizeof(remote));
+    remote.r_rip = address;
+    /*
+     * Do not synthesize RSP/RBP here. The working v1.0.0 pt_call2 changes RIP
+     * and the argument registers only, so the short stager borrows the stack
+     * of the already-stopped ShellUI thread until its INT3. Restoring every
+     * original register below makes that temporary use invisible afterwards.
+     */
+    remote.r_rdi = arg0;
+    remote.r_rsi = arg1;
+    remote.r_rdx = arg2;
+    remote.r_rcx = arg3;
+    remote.r_r8 = arg4;
+    remote.r_r9 = arg5;
+
+    if (pt_setregs(pid, &remote) != 0)
+        return -1;
+
+    if (pt_continue(pid, SIGCONT) != 0) {
+        (void)pt_setregs(pid, &original);
+        return -1;
+    }
+
+    if (waitpid(pid, nullptr, 0) < 0) {
+        (void)pt_setregs(pid, &original);
+        return -1;
+    }
+
+    reg stopped{};
+    if (pt_getregs(pid, &stopped) != 0) {
+        (void)pt_setregs(pid, &original);
+        return -1;
+    }
+
+    if (pt_setregs(pid, &original) != 0)
+        return -1;
+
+    return static_cast<long>(stopped.r_rax);
+}
+
+} // namespace common_fps::ps5

--- a/src/ps5/remote_call.hpp
+++ b/src/ps5/remote_call.hpp
@@ -1,0 +1,29 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <cstdint>
+#include <sys/types.h>
+
+namespace common_fps::ps5 {
+
+/*
+ * Call a function while the target is already ptrace-attached. The remote
+ * bootstrap must execute INT3 before returning. Match the hardware-stable
+ * v1.0.0 pt_call2 contract by preserving the stopped target thread's RSP and
+ * RBP; the original register set is restored before this function returns.
+ */
+[[nodiscard]] long call_until_breakpoint_on_target_stack(
+    pid_t pid,
+    std::uintptr_t address,
+    std::uint64_t arg0 = 0,
+    std::uint64_t arg1 = 0,
+    std::uint64_t arg2 = 0,
+    std::uint64_t arg3 = 0,
+    std::uint64_t arg4 = 0,
+    std::uint64_t arg5 = 0) noexcept;
+
+} // namespace common_fps::ps5

--- a/src/ps5/shellui_blob.hpp
+++ b/src/ps5/shellui_blob.hpp
@@ -1,0 +1,11 @@
+/*
+ * Generated ShellUI ELF declarations.
+ * The byte array itself is generated at build time from source.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+extern const std::uint8_t commonfps_shellui_elf[];
+extern const std::size_t commonfps_shellui_elf_size;

--- a/src/ps5/shellui_injector.cpp
+++ b/src/ps5/shellui_injector.cpp
@@ -1,0 +1,641 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "shellui_injector.hpp"
+#if defined(COMMON_FPS_TEST29_NO_AUTH_ONLY)
+#elif defined(COMMON_FPS_TEST28_AUTH_DIRECT_ONLY)
+#include "shellui_auth_direct_probe.hpp"
+#elif defined(COMMON_FPS_TEST27_AUTH_ONLY)
+#include "shellui_auth_probe.hpp"
+#elif defined(COMMON_FPS_TEST26_ATTACH_DETACH_ONLY)
+#include "shellui_attach_probe.hpp"
+#else
+#include "shellui_blob.hpp"
+#include "stable_shellui_injector.hpp"
+#endif
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sys/time.h>
+#include <unistd.h>
+
+#if !defined(COMMON_FPS_DIAGNOSTIC_SYSCTL_ONLY)
+extern "C" {
+#include "proc.h"
+}
+#endif
+
+namespace common_fps::ps5 {
+namespace {
+
+#if !defined(COMMON_FPS_TEST25_LOAD_ONLY) && \
+    !defined(COMMON_FPS_TEST26_ATTACH_DETACH_ONLY) && \
+    !defined(COMMON_FPS_TEST27_AUTH_ONLY) && \
+    !defined(COMMON_FPS_TEST28_AUTH_DIRECT_ONLY) && \
+    !defined(COMMON_FPS_TEST29_NO_AUTH_ONLY)
+constexpr const char* kMarker = "/system_tmp/commonfps_shellui.pid";
+#endif
+#if defined(COMMON_FPS_TEST29_NO_AUTH_ONLY)
+constexpr const char* kLog =
+    "/data/CommonFPS_v110_test29_no_auth_only.log";
+#elif defined(COMMON_FPS_TEST28_AUTH_DIRECT_ONLY)
+constexpr const char* kLog =
+    "/data/CommonFPS_v110_test28_auth_direct_only.log";
+#elif defined(COMMON_FPS_TEST27_AUTH_ONLY)
+constexpr const char* kLog =
+    "/data/CommonFPS_v110_test27_auth_only.log";
+#elif defined(COMMON_FPS_TEST26_ATTACH_DETACH_ONLY)
+constexpr const char* kLog =
+    "/data/CommonFPS_v110_test26_attach_detach_only.log";
+#elif defined(COMMON_FPS_TEST25_LOAD_ONLY)
+constexpr const char* kLog =
+    "/data/CommonFPS_v110_test25_load_only_no_pthread.log";
+#elif defined(COMMON_FPS_TEST31_TRACKED_RENDERER)
+constexpr const char* kLog =
+    "/data/CommonFPS_v110_test31_tracked_renderer.log";
+#else
+constexpr const char* kLog = "/data/CommonFPS_v110_source.log";
+#endif
+constexpr const char* kShellUiName = "SceShellUI";
+pid_t g_last_shellui_pid = -1;
+
+std::uint64_t now_ms() noexcept {
+    timeval tv{};
+    gettimeofday(&tv, nullptr);
+    return static_cast<std::uint64_t>(tv.tv_sec) * 1000ULL +
+        static_cast<std::uint64_t>(tv.tv_usec) / 1000ULL;
+}
+
+/*
+ * The FW 9.60 PARITY TEST2 binary proved this Sony kinfo_proc layout on
+ * hardware.  PS5's returned record is not the stock FreeBSD structure from
+ * the open SDK headers, so use checked byte offsets instead of casting it.
+ */
+constexpr long kSysctlSyscall = 202;
+constexpr int kCtlKern = 1;
+constexpr int kKernProc = 14;
+constexpr int kKernProcProc = 8;
+constexpr std::size_t kPidOffset = 72;
+constexpr std::size_t kTdnameOffset = 447;
+
+enum class ShellUiLookupPath {
+    None,
+    SysctlThreadName,
+#if !defined(COMMON_FPS_DIAGNOSTIC_SYSCTL_ONLY)
+    KernelAllprocFallback,
+#endif
+};
+
+struct ShellUiLookupResult {
+    pid_t pid = -1;
+    ShellUiLookupPath path = ShellUiLookupPath::None;
+    int size_query_rc = -1;
+    int data_query_rc = -1;
+    int saved_errno = 0;
+    std::size_t bytes = 0;
+    unsigned records = 0;
+    unsigned malformed_records = 0;
+};
+
+bool exact_process_name(
+    const char* field,
+    std::size_t field_size) noexcept {
+
+    constexpr std::size_t name_size = sizeof("SceShellUI") - 1;
+    return field_size > name_size &&
+        std::memcmp(field, kShellUiName, name_size) == 0 &&
+        field[name_size] == '\0';
+}
+
+const char* lookup_path_name(ShellUiLookupPath path) noexcept {
+    switch (path) {
+    case ShellUiLookupPath::SysctlThreadName:
+        return "sysctl_tdname";
+#if !defined(COMMON_FPS_DIAGNOSTIC_SYSCTL_ONLY)
+    case ShellUiLookupPath::KernelAllprocFallback:
+        return "kernel_allproc";
+#endif
+    case ShellUiLookupPath::None:
+        break;
+    }
+    return "none";
+}
+
+ShellUiLookupResult find_shellui_pid() noexcept {
+    ShellUiLookupResult result{};
+
+    int mib[4] = {
+        kCtlKern,
+        kKernProc,
+        kKernProcProc,
+        0,
+    };
+
+    std::size_t required = 0;
+    result.size_query_rc = static_cast<int>(syscall(
+        kSysctlSyscall,
+        mib,
+        4,
+        nullptr,
+        &required,
+        nullptr,
+        0));
+
+    if (result.size_query_rc == 0 && required != 0) {
+        /* Leave headroom if the process list grows between the two calls. */
+        const std::size_t capacity = required + required / 4 + 4096;
+        auto* buffer = static_cast<std::uint8_t*>(std::malloc(capacity));
+
+        if (buffer) {
+            result.bytes = capacity;
+            result.data_query_rc = static_cast<int>(syscall(
+                kSysctlSyscall,
+                mib,
+                4,
+                buffer,
+                &result.bytes,
+                nullptr,
+                0));
+
+            if (result.data_query_rc == 0) {
+                std::uint8_t* cursor = buffer;
+                const std::uint8_t* const end = buffer + result.bytes;
+
+                while (cursor < end) {
+                    const std::size_t remaining =
+                        static_cast<std::size_t>(end - cursor);
+                    if (remaining < sizeof(int)) {
+                        ++result.malformed_records;
+                        break;
+                    }
+
+                    int record_size = 0;
+                    std::memcpy(
+                        &record_size,
+                        cursor,
+                        sizeof(record_size));
+                    if (record_size <= 0 ||
+                        static_cast<std::size_t>(record_size) > remaining) {
+                        ++result.malformed_records;
+                        break;
+                    }
+
+                    ++result.records;
+                    const std::size_t usable =
+                        static_cast<std::size_t>(record_size);
+                    const bool has_proven_fields = usable >=
+                        kTdnameOffset + sizeof("SceShellUI");
+
+                    pid_t candidate_pid = -1;
+                    if (has_proven_fields) {
+                        std::memcpy(
+                            &candidate_pid,
+                            cursor + kPidOffset,
+                            sizeof(candidate_pid));
+                    }
+
+                    if (candidate_pid > 0 &&
+                        candidate_pid != getpid() &&
+                        exact_process_name(
+                            reinterpret_cast<const char*>(
+                                cursor + kTdnameOffset),
+                            usable - kTdnameOffset)) {
+                        result.pid = candidate_pid;
+                        result.path =
+                            ShellUiLookupPath::SysctlThreadName;
+                        break;
+                    }
+
+                    cursor += record_size;
+                }
+            } else {
+                result.saved_errno = errno;
+            }
+
+            std::free(buffer);
+        } else {
+            result.saved_errno = ENOMEM;
+        }
+    } else {
+        result.saved_errno = errno;
+    }
+
+    if (result.pid > 0)
+        return result;
+
+#if !defined(COMMON_FPS_DIAGNOSTIC_SYSCTL_ONLY)
+    /* Keep the former allproc path only as a secondary compatibility path. */
+    if (struct proc* process = find_proc_by_name(kShellUiName)) {
+        result.pid = process->pid;
+        result.path = ShellUiLookupPath::KernelAllprocFallback;
+        std::free(process);
+    }
+#endif
+
+    return result;
+}
+
+void log_line(const char* fmt, ...) {
+    FILE* fp = std::fopen(kLog, "a");
+    if (!fp)
+        return;
+
+    va_list ap;
+    va_start(ap, fmt);
+    std::vfprintf(fp, fmt, ap);
+    va_end(ap);
+    std::fputc('\n', fp);
+    std::fclose(fp);
+}
+
+#if !defined(COMMON_FPS_TEST25_LOAD_ONLY) && \
+    !defined(COMMON_FPS_TEST26_ATTACH_DETACH_ONLY) && \
+    !defined(COMMON_FPS_TEST27_AUTH_ONLY) && \
+    !defined(COMMON_FPS_TEST28_AUTH_DIRECT_ONLY) && \
+    !defined(COMMON_FPS_TEST29_NO_AUTH_ONLY)
+bool marker_matches(pid_t pid) {
+    FILE* fp = std::fopen(kMarker, "r");
+    if (!fp)
+        return false;
+
+    int marked_pid = -1;
+    const int rc = std::fscanf(fp, "%d", &marked_pid);
+    std::fclose(fp);
+    return rc == 1 && marked_pid == pid;
+}
+#endif
+
+} // namespace
+
+bool ensure_shellui_renderer() {
+    static pid_t attempted_pid = -1;
+    static bool attempted_result = false;
+    static bool retry_allowed = true;
+    static unsigned retry_delay_ticks = 0;
+    static unsigned discovery_failures = 0;
+
+    const ShellUiLookupResult lookup = find_shellui_pid();
+    if (lookup.pid <= 0) {
+        ++discovery_failures;
+        if (discovery_failures == 1 || discovery_failures % 30 == 0) {
+            log_line(
+                "ShellUI lookup failed sysctl=%d/%d errno=%d "
+                "bytes=%zu records=%u malformed=%u",
+                lookup.size_query_rc,
+                lookup.data_query_rc,
+                lookup.saved_errno,
+                lookup.bytes,
+                lookup.records,
+                lookup.malformed_records);
+        }
+        return false;
+    }
+
+    discovery_failures = 0;
+    const pid_t pid = lookup.pid;
+    g_last_shellui_pid = pid;
+
+#if !defined(COMMON_FPS_TEST25_LOAD_ONLY) && \
+    !defined(COMMON_FPS_TEST26_ATTACH_DETACH_ONLY) && \
+    !defined(COMMON_FPS_TEST27_AUTH_ONLY) && \
+    !defined(COMMON_FPS_TEST28_AUTH_DIRECT_ONLY) && \
+    !defined(COMMON_FPS_TEST29_NO_AUTH_ONLY)
+    if (marker_matches(pid))
+        return true;
+#endif
+
+    if (attempted_pid != pid) {
+        log_line(
+            "ShellUI lookup pid=%d via=%s bytes=%zu records=%u "
+            "malformed=%u",
+            pid,
+            lookup_path_name(lookup.path),
+            lookup.bytes,
+            lookup.records,
+            lookup.malformed_records);
+        attempted_pid = pid;
+        attempted_result = false;
+        retry_allowed = true;
+        retry_delay_ticks = 0;
+    } else if (attempted_result) {
+        return true;
+    } else if (!retry_allowed) {
+        return false;
+    } else if (retry_delay_ticks != 0) {
+        --retry_delay_ticks;
+        return false;
+    }
+
+    attempted_result = false;
+
+#if defined(COMMON_FPS_TEST29_NO_AUTH_ONLY)
+    log_line("ShellUI auth-free start pid=%d", pid);
+
+    const std::uint64_t probe_started_ms = now_ms();
+    attempted_result = true;
+    retry_allowed = false;
+
+    log_line(
+        "ShellUI auth-free complete pid=%d auth_change=0 "
+        "kernel_set_authid=0 ptrace_attach=0 ptrace_detach=0 sigcont=0 "
+        "elf_load=0 payload_args=0 remote_mappings=0 stager=0 "
+        "register_writes=0 remote_calls=0 elapsed_ms=%llu",
+        pid,
+        static_cast<unsigned long long>(now_ms() - probe_started_ms));
+    return true;
+#elif defined(COMMON_FPS_TEST28_AUTH_DIRECT_ONLY)
+    log_line("ShellUI auth-direct start pid=%d", pid);
+
+    const std::uint64_t probe_started_ms = now_ms();
+    const ShellUiAuthDirectProbeResult probe =
+        probe_shellui_direct_auth_transition();
+
+    log_line(
+        "ShellUI auth-direct ucred=%d original_read=%d change=%d "
+        "target_verify=%d restore_verify=%d "
+        "auth_before=0x%llx auth_during=0x%llx auth_after=0x%llx "
+        "kernel_set_authid=0 ptrace_attach=0 ptrace_detach=0 sigcont=0 "
+        "elf_load=0 payload_args=0 remote_mappings=0 stager=0 "
+        "register_writes=0 remote_calls=0 elapsed_ms=%llu",
+        probe.ucred_found ? 1 : 0,
+        probe.original_read ? 1 : 0,
+        probe.auth_changed ? 1 : 0,
+        probe.direct_auth_verified ? 1 : 0,
+        probe.auth_restored ? 1 : 0,
+        static_cast<unsigned long long>(probe.original_auth),
+        static_cast<unsigned long long>(probe.observed_direct_auth),
+        static_cast<unsigned long long>(probe.observed_restored_auth),
+        static_cast<unsigned long long>(now_ms() - probe_started_ms));
+
+    const bool probe_complete =
+        probe.ucred_found &&
+        probe.original_read &&
+        probe.auth_changed &&
+        probe.direct_auth_verified &&
+        probe.auth_restored;
+
+    attempted_result = probe_complete;
+    retry_allowed = false;
+
+    if (!probe_complete) {
+        log_line(
+            "ShellUI auth-direct failed pid=%d retry=no",
+            pid);
+        return false;
+    }
+
+    log_line(
+        "ShellUI auth-direct complete pid=%d total_ms=%llu",
+        pid,
+        static_cast<unsigned long long>(now_ms() - probe_started_ms));
+    return true;
+#elif defined(COMMON_FPS_TEST27_AUTH_ONLY)
+    log_line("ShellUI ptrace-auth-only start pid=%d", pid);
+
+    const std::uint64_t probe_started_ms = now_ms();
+    const ShellUiAuthProbeResult probe =
+        probe_shellui_ptrace_auth_transition();
+
+    log_line(
+        "ShellUI ptrace-auth-only original_read=%d change=%d "
+        "target_verify=%d restore_verify=%d "
+        "auth_before=0x%llx auth_during=0x%llx auth_after=0x%llx "
+        "ptrace_attach=0 ptrace_detach=0 sigcont=0 "
+        "elf_load=0 payload_args=0 remote_mappings=0 stager=0 "
+        "register_writes=0 remote_calls=0 elapsed_ms=%llu",
+        probe.original_read ? 1 : 0,
+        probe.auth_changed ? 1 : 0,
+        probe.ptrace_auth_verified ? 1 : 0,
+        probe.auth_restored ? 1 : 0,
+        static_cast<unsigned long long>(probe.original_auth),
+        static_cast<unsigned long long>(probe.observed_ptrace_auth),
+        static_cast<unsigned long long>(probe.observed_restored_auth),
+        static_cast<unsigned long long>(now_ms() - probe_started_ms));
+
+    const bool probe_complete =
+        probe.original_read &&
+        probe.auth_changed &&
+        probe.ptrace_auth_verified &&
+        probe.auth_restored;
+
+    attempted_result = probe_complete;
+    retry_allowed = false;
+
+    if (!probe_complete) {
+        log_line(
+            "ShellUI ptrace-auth-only failed pid=%d retry=no",
+            pid);
+        return false;
+    }
+
+    log_line(
+        "ShellUI ptrace-auth-only complete pid=%d total_ms=%llu",
+        pid,
+        static_cast<unsigned long long>(now_ms() - probe_started_ms));
+    return true;
+#elif defined(COMMON_FPS_TEST26_ATTACH_DETACH_ONLY)
+    log_line("ShellUI attach-detach start pid=%d", pid);
+
+    const std::uint64_t probe_started_ms = now_ms();
+    const ShellUiAttachProbeResult probe =
+        probe_shellui_attach_detach(pid);
+
+    log_line(
+        "ShellUI attach-detach auth=%d/%d attach=%d detach=%d "
+        "sigcont=%d elf_load=0 payload_args=0 remote_mappings=0 "
+        "stager=0 register_writes=0 remote_calls=0 "
+        "elapsed_ms=%llu",
+        probe.auth_changed ? 1 : 0,
+        probe.auth_restored ? 1 : 0,
+        probe.attached ? 1 : 0,
+        probe.detached ? 1 : 0,
+        probe.sigcont_sent ? 1 : 0,
+        static_cast<unsigned long long>(now_ms() - probe_started_ms));
+
+    const bool probe_complete =
+        probe.auth_changed &&
+        probe.auth_restored &&
+        probe.attached &&
+        probe.detached &&
+        probe.sigcont_sent;
+
+    if (!probe_complete) {
+        retry_allowed = !probe.attached;
+        retry_delay_ticks = retry_allowed ? 5U : 0U;
+        log_line(
+            "ShellUI attach-detach failed pid=%d retry=%s",
+            pid,
+            retry_allowed ? "yes" : "no");
+        return false;
+    }
+
+    attempted_result = true;
+    retry_allowed = false;
+    log_line(
+        "ShellUI attach-detach complete pid=%d total_ms=%llu",
+        pid,
+        static_cast<unsigned long long>(now_ms() - probe_started_ms));
+    return true;
+#else
+    log_line(
+        "ShellUI inject start pid=%d payload_size=%zu",
+        pid,
+        commonfps_shellui_elf_size);
+
+    const std::uint64_t inject_started_ms = now_ms();
+
+    const StableInjectionResult injected = inject_shellui_stable(
+        pid,
+        commonfps_shellui_elf,
+        commonfps_shellui_elf_size,
+#if defined(COMMON_FPS_TEST25_LOAD_ONLY)
+        StableInjectionMode::ExerciseStagerWithoutThread);
+#else
+        StableInjectionMode::StartRendererThread);
+#endif
+
+#if defined(COMMON_FPS_TEST25_LOAD_ONLY)
+    log_line(
+        "ShellUI load-only auth=%d/%d attach=%d load=%d args=%d "
+        "stager=%d functions=%d target_stack=%d call=%d "
+        "thread_request=%d thread_created=%d rc=%d detach=%d "
+        "trace=%d/%d imports=%u/%u first=%s elapsed_ms=%llu",
+        injected.auth_changed ? 1 : 0,
+        injected.auth_restored ? 1 : 0,
+        injected.attached ? 1 : 0,
+        injected.elf_loaded ? 1 : 0,
+        injected.payload_args_ready ? 1 : 0,
+        injected.remote_stager_ready ? 1 : 0,
+        injected.remote_functions_ready ? 1 : 0,
+        injected.target_stack_preserved ? 1 : 0,
+        injected.bootstrap_started ? 1 : 0,
+        injected.thread_start_requested ? 1 : 0,
+        injected.pthread_create_ok ? 1 : 0,
+        injected.pthread_create_rc,
+        injected.detached ? 1 : 0,
+        injected.trace_continue_seen ? 1 : 0,
+        injected.trace_stop_seen ? 1 : 0,
+        injected.imports_resolved,
+        injected.imports_unresolved,
+        injected.first_unresolved && *injected.first_unresolved
+            ? injected.first_unresolved
+            : "none",
+        static_cast<unsigned long long>(now_ms() - inject_started_ms));
+
+    const bool load_only_complete =
+        injected.auth_changed &&
+        injected.auth_restored &&
+        injected.attached &&
+        injected.elf_loaded &&
+        injected.payload_args_ready &&
+        injected.remote_stager_ready &&
+        injected.remote_functions_ready &&
+        injected.target_stack_preserved &&
+        injected.bootstrap_started &&
+        !injected.thread_start_requested &&
+        !injected.pthread_create_ok &&
+        injected.pthread_create_rc == kPthreadCreateSkippedRc &&
+        injected.detached &&
+        injected.trace_continue_seen &&
+        injected.trace_stop_seen &&
+        injected.imports_unresolved == 0;
+
+    if (!load_only_complete) {
+        retry_allowed = !injected.elf_loaded;
+        retry_delay_ticks = retry_allowed ? 5U : 0U;
+        log_line(
+            "ShellUI load-only failed pid=%d retry=%s",
+            pid,
+            retry_allowed ? "yes" : "no");
+        return false;
+    }
+
+    attempted_result = true;
+    retry_allowed = false;
+    log_line(
+        "ShellUI image mapped no-thread pid=%d total_ms=%llu",
+        pid,
+        static_cast<unsigned long long>(now_ms() - inject_started_ms));
+    return true;
+#else
+    log_line(
+        "ShellUI bootstrap auth=%d/%d attach=%d load=%d args=%d "
+        "target_stack=%d thread=%d rc=%d detach=%d trace=%d/%d "
+        "imports=%u/%u first=%s elapsed_ms=%llu",
+        injected.auth_changed ? 1 : 0,
+        injected.auth_restored ? 1 : 0,
+        injected.attached ? 1 : 0,
+        injected.elf_loaded ? 1 : 0,
+        injected.payload_args_ready ? 1 : 0,
+        injected.target_stack_preserved ? 1 : 0,
+        injected.bootstrap_started ? 1 : 0,
+        injected.pthread_create_rc,
+        injected.detached ? 1 : 0,
+        injected.trace_continue_seen ? 1 : 0,
+        injected.trace_stop_seen ? 1 : 0,
+        injected.imports_resolved,
+        injected.imports_unresolved,
+        injected.first_unresolved && *injected.first_unresolved
+            ? injected.first_unresolved
+            : "none",
+        static_cast<unsigned long long>(now_ms() - inject_started_ms));
+
+    if (!injected.pthread_create_ok || !injected.auth_restored) {
+        /*
+         * A failure before the ELF image was committed is safe to retry after
+         * a short delay.  Once a remote image/thread may exist, do not stack a
+         * second copy in the same ShellUI process.
+         */
+        retry_allowed = !injected.elf_loaded;
+        retry_delay_ticks = retry_allowed ? 5U : 0U;
+        log_line(
+            "ShellUI stable bootstrap failed pid=%d retry=%s",
+            pid,
+            retry_allowed ? "yes" : "no");
+        return false;
+    }
+
+    /*
+     * v1.0.0 waited for Scene/PUI readiness.  The source renderer retries for
+     * up to 60 seconds, so the controller waits slightly longer for its
+     * marker instead of starting game sampling prematurely.
+     */
+    for (int i = 0; i < 3500; ++i) {
+        if (marker_matches(pid)) {
+            attempted_result = true;
+            log_line(
+                "ShellUI renderer online pid=%d total_ms=%llu",
+                pid,
+                static_cast<unsigned long long>(
+                    now_ms() - inject_started_ms));
+            return true;
+        }
+        usleep(20000);
+    }
+
+    log_line("ShellUI marker timeout pid=%d", pid);
+    retry_allowed = false;
+    return false;
+#endif
+#endif
+}
+
+pid_t observe_shellui_pid() noexcept {
+    const ShellUiLookupResult lookup = find_shellui_pid();
+    g_last_shellui_pid = lookup.pid;
+    return lookup.pid;
+}
+
+pid_t shellui_renderer_pid() noexcept {
+    return g_last_shellui_pid;
+}
+
+} // namespace common_fps::ps5

--- a/src/ps5/shellui_injector.hpp
+++ b/src/ps5/shellui_injector.hpp
@@ -1,0 +1,22 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <cstdarg>
+#include <sys/types.h>
+
+namespace common_fps::ps5 {
+
+/* Ensure the source-built renderer is resident in the current SceShellUI. */
+bool ensure_shellui_renderer();
+
+/* Discover ShellUI without attaching, injecting or changing the process. */
+pid_t observe_shellui_pid() noexcept;
+
+/* Last ShellUI PID observed by the read-only discovery path. */
+pid_t shellui_renderer_pid() noexcept;
+
+} // namespace common_fps::ps5

--- a/src/ps5/shellui_payload/commonfps_shellui.cpp
+++ b/src/ps5/shellui_payload/commonfps_shellui.cpp
@@ -6,71 +6,727 @@
  */
 
 /*
- * Source-only Common FPS ShellUI renderer.
+ * Source-only ShellUI renderer.
  *
- * Upstream API style follows etaHEN's GPL shellui implementation:
- * HookFunctions.cpp -> CreateGameWidget()/RemoveGameWidget().
- *
- * This file intentionally does not embed or depend on the historical
- * PHU libphu_overlay.so binary.
+ * The historical v1.0.0 binary embedded PHU's renderer.  v1.1.0 replaces
+ * that blob with this small, auditable PUI implementation. PARITY TEST13
+ * leaves the TEST12 shared-ELF/Application.Update, pinned-GC-handle and
+ * two-second socket receive-timeout behavior unchanged while the controller
+ * isolates the bootstrap-stack parity difference.
  */
 
 #include "commonfps_shellui.hpp"
 
-#include "HookedFuncs.hpp"
-
 #include <arpa/inet.h>
 #include <atomic>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <netinet/in.h>
 #include <pthread.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 namespace common_fps::ps5::shellui {
 
 namespace {
 
-std::atomic_bool g_running{false};
+static_assert(SOL_SOCKET == 0xffff);
+static_assert(SO_RCVTIMEO == 0x1006);
+static_assert(sizeof(timeval) == 16);
+
+/* Mono is intentionally represented by opaque types here. */
+struct MonoDomain;
+struct MonoThread;
+struct MonoAssembly;
+struct MonoImage;
+struct MonoClass;
+struct MonoMethod;
+struct MonoProperty;
+struct MonoObject;
+struct MonoString;
+
+using mono_get_root_domain_t = MonoDomain* (*)();
+using mono_domain_get_t = MonoDomain* (*)();
+using mono_thread_attach_t = MonoThread* (*)(MonoDomain*);
+using mono_domain_assembly_open_t = MonoAssembly* (*)(MonoDomain*, const char*);
+using mono_assembly_get_image_t = MonoImage* (*)(MonoAssembly*);
+using mono_class_from_name_t = MonoClass* (*)(MonoImage*, const char*, const char*);
+using mono_class_get_method_from_name_t = MonoMethod* (*)(MonoClass*, const char*, int);
+using mono_class_get_property_from_name_t = MonoProperty* (*)(MonoClass*, const char*);
+using mono_property_get_get_method_t = MonoMethod* (*)(MonoProperty*);
+using mono_property_get_set_method_t = MonoMethod* (*)(MonoProperty*);
+using mono_runtime_invoke_t = MonoObject* (*)(MonoMethod*, void*, void**, MonoObject**);
+using mono_string_new_t = MonoString* (*)(MonoDomain*, const char*);
+using mono_object_new_t = MonoObject* (*)(MonoDomain*, MonoClass*);
+using mono_runtime_object_init_t = void (*)(MonoObject*);
+using mono_object_unbox_t = void* (*)(MonoObject*);
+using mono_compile_method_t = void* (*)(MonoMethod*);
+using mono_gchandle_new_t = std::uint32_t (*)(MonoObject*, int);
+using mono_gchandle_get_target_t = MonoObject* (*)(std::uint32_t);
+using mono_gchandle_free_t = void (*)(std::uint32_t);
+
+/*
+ * The injector resolves these imports against ShellUI's already-loaded Mono
+ * module before the remote thread starts.  This deliberately avoids linking
+ * the PS5 payload CRT merely to call kernel_dynlib_handle/dlsym from inside
+ * ShellUI.  The stable v1.0.0 renderer used the same direct-import shape.
+ */
+extern "C" {
+MonoDomain* mono_get_root_domain();
+MonoDomain* mono_domain_get();
+MonoThread* mono_thread_attach(MonoDomain*);
+MonoAssembly* mono_domain_assembly_open(MonoDomain*, const char*);
+MonoImage* mono_assembly_get_image(MonoAssembly*);
+MonoClass* mono_class_from_name(MonoImage*, const char*, const char*);
+MonoMethod* mono_class_get_method_from_name(MonoClass*, const char*, int);
+MonoProperty* mono_class_get_property_from_name(MonoClass*, const char*);
+MonoMethod* mono_property_get_get_method(MonoProperty*);
+MonoMethod* mono_property_get_set_method(MonoProperty*);
+MonoObject* mono_runtime_invoke(MonoMethod*, void*, void**, MonoObject**);
+MonoString* mono_string_new(MonoDomain*, const char*);
+MonoObject* mono_object_new(MonoDomain*, MonoClass*);
+void mono_runtime_object_init(MonoObject*);
+void* mono_object_unbox(MonoObject*);
+void* mono_compile_method(MonoMethod*);
+std::uint32_t mono_gchandle_new(MonoObject*, int);
+MonoObject* mono_gchandle_get_target(std::uint32_t);
+void mono_gchandle_free(std::uint32_t);
+}
+
+mono_get_root_domain_t mono_get_root_domain_ = mono_get_root_domain;
+mono_domain_get_t mono_domain_get_ = mono_domain_get;
+mono_thread_attach_t mono_thread_attach_ = mono_thread_attach;
+mono_domain_assembly_open_t mono_domain_assembly_open_ =
+    mono_domain_assembly_open;
+mono_assembly_get_image_t mono_assembly_get_image_ = mono_assembly_get_image;
+mono_class_from_name_t mono_class_from_name_ = mono_class_from_name;
+mono_class_get_method_from_name_t mono_class_get_method_from_name_ =
+    mono_class_get_method_from_name;
+mono_class_get_property_from_name_t mono_class_get_property_from_name_ =
+    mono_class_get_property_from_name;
+mono_property_get_get_method_t mono_property_get_get_method_ =
+    mono_property_get_get_method;
+mono_property_get_set_method_t mono_property_get_set_method_ =
+    mono_property_get_set_method;
+mono_runtime_invoke_t mono_runtime_invoke_ = mono_runtime_invoke;
+mono_string_new_t mono_string_new_ = mono_string_new;
+mono_object_new_t mono_object_new_ = mono_object_new;
+mono_runtime_object_init_t mono_runtime_object_init_ =
+    mono_runtime_object_init;
+mono_object_unbox_t mono_object_unbox_ = mono_object_unbox;
+mono_compile_method_t mono_compile_method_ = mono_compile_method;
+mono_gchandle_new_t mono_gchandle_new_ = mono_gchandle_new;
+mono_gchandle_get_target_t mono_gchandle_get_target_ =
+    mono_gchandle_get_target;
+mono_gchandle_free_t mono_gchandle_free_ = mono_gchandle_free;
+
+MonoDomain* g_domain{};
+MonoImage* g_pui_image{};
+std::uint32_t g_game_scene_handle{};
+std::uint32_t g_label_handle{};
+std::uint32_t g_value_handle{};
+
+using application_update_t = void (*)(MonoObject*);
+application_update_t g_application_update_original{};
+
+std::atomic_bool g_runtime_ready{false};
 std::atomic_bool g_have_packet{false};
 std::atomic<std::uint64_t> g_sequence{0};
+std::atomic<std::uint64_t> g_applied_sequence{0};
 
-pthread_t g_thread{};
+int g_receiver_fd = -1;
 WirePacket g_packet{};
 pthread_mutex_t g_packet_lock = PTHREAD_MUTEX_INITIALIZER;
 
 constexpr const char* kLabelId = "id_commonfps_label";
 constexpr const char* kValueId = "id_commonfps_value";
+constexpr const char* kPuiDll =
+    "/system_ex/common_ex/lib/Sce.PlayStation.PUI.dll";
+constexpr const char* kAppSystemDll =
+    "/system_ex/common_ex/lib/Sce.Vsh.ShellUI.AppSystem.dll";
 
-void remove_widget(MonoObject* root, const char* id) {
-    MonoClass* widgetClass =
-        mono_class_from_name(
-            pui_img,
-            "Sce.PlayStation.PUI.UI2",
-            "Widget");
-
-    MonoObject* child =
-        Invoke<MonoObject*>(
-            pui_img,
-            widgetClass,
-            root,
-            "FindWidgetByName",
-            mono_string_new(Root_Domain, id));
-
-    if (child) {
-        Invoke<void>(
-            pui_img,
-            widgetClass,
-            child,
-            "RemoveFromParent");
-    }
+/*
+ * etaHEN installs an x86-64 absolute-indirect jump at Application.Update:
+ *
+ *   FF 25 00 00 00 00 <eight-byte destination>
+ *
+ * TEST13 only chains that already-proven hook. It never disassembles or
+ * overwrites an unhooked Sony method. The trampoline lives in this payload's
+ * RWE text segment and receives an exact copy of etaHEN's 14-byte jump.
+ */
+extern "C" __attribute__((naked, noinline, used, aligned(16)))
+void commonfps_update_trampoline() {
+    __asm__ volatile(
+        ".rept 32\n"
+        "nop\n"
+        ".endr\n"
+        "ret\n");
 }
 
-void* receiver_thread(void*) {
-    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (fd < 0)
+void application_update_hook(MonoObject* instance);
+
+void log_line(const char* fmt, ...) {
+    FILE* fp = std::fopen("/data/CommonFPS_v110_shellui.log", "a");
+    if (!fp)
+        return;
+
+    va_list ap;
+    va_start(ap, fmt);
+    std::vfprintf(fp, fmt, ap);
+    va_end(ap);
+    std::fputc('\n', fp);
+    std::fclose(fp);
+}
+
+MonoImage* open_image(const char* path) {
+    if (!g_domain || !mono_domain_assembly_open_ || !mono_assembly_get_image_)
         return nullptr;
+
+    MonoAssembly* assembly = mono_domain_assembly_open_(g_domain, path);
+    return assembly ? mono_assembly_get_image_(assembly) : nullptr;
+}
+
+MonoObject* invoke(
+    MonoMethod* method,
+    MonoObject* instance,
+    void** args = nullptr) {
+
+    if (!method || !mono_runtime_invoke_)
+        return nullptr;
+
+    MonoObject* exception = nullptr;
+    MonoObject* result = mono_runtime_invoke_(
+        method,
+        instance,
+        args,
+        &exception);
+
+    return exception ? nullptr : result;
+}
+
+MonoMethod* property_getter(MonoClass* klass, const char* name) {
+    if (!klass)
+        return nullptr;
+    MonoProperty* property =
+        mono_class_get_property_from_name_(klass, name);
+    return property ? mono_property_get_get_method_(property) : nullptr;
+}
+
+MonoMethod* property_setter(MonoClass* klass, const char* name) {
+    if (!klass)
+        return nullptr;
+    MonoProperty* property =
+        mono_class_get_property_from_name_(klass, name);
+    return property ? mono_property_get_set_method_(property) : nullptr;
+}
+
+MonoObject* managed_target(std::uint32_t handle) {
+    return handle != 0 && mono_gchandle_get_target_
+        ? mono_gchandle_get_target_(handle)
+        : nullptr;
+}
+
+bool replace_managed_handle(
+    std::uint32_t& handle,
+    MonoObject* object) {
+
+    if (!object || !mono_gchandle_new_ || !mono_gchandle_get_target_)
+        return false;
+
+    if (handle != 0 && managed_target(handle) == object)
+        return true;
+
+    if (handle != 0 && mono_gchandle_free_)
+        mono_gchandle_free_(handle);
+
+    /* Match the hardware-stable v1.0.0 renderer: retain a pinned object. */
+    handle = mono_gchandle_new_(object, 1);
+    return handle != 0 && managed_target(handle) == object;
+}
+
+template <typename T>
+bool set_property_direct(
+    MonoClass* klass,
+    MonoObject* instance,
+    const char* name,
+    T value) {
+
+    MonoMethod* setter = property_setter(klass, name);
+    if (!setter)
+        return false;
+
+    void* thunk = mono_compile_method_(setter);
+    if (!thunk)
+        return false;
+
+    auto fn = reinterpret_cast<void (*)(MonoObject*, T)>(thunk);
+    fn(instance, value);
+    return true;
+}
+
+bool set_property_object(
+    MonoClass* klass,
+    MonoObject* instance,
+    const char* name,
+    MonoObject* value) {
+
+    MonoMethod* setter = property_setter(klass, name);
+    if (!setter)
+        return false;
+
+    void* args[1] = {value};
+    MonoObject* exception = nullptr;
+    mono_runtime_invoke_(setter, instance, args, &exception);
+    return exception == nullptr;
+}
+
+MonoObject* get_root_widget() {
+    MonoObject* game_scene = managed_target(g_game_scene_handle);
+    if (!game_scene)
+        return nullptr;
+
+    MonoClass* scene = mono_class_from_name_(
+        g_pui_image,
+        "Sce.PlayStation.PUI.UI2",
+        "Scene");
+    MonoMethod* getter = property_getter(scene, "RootWidget");
+    return getter ? invoke(getter, game_scene) : nullptr;
+}
+
+MonoObject* create_font(int size) {
+    MonoClass* klass = mono_class_from_name_(
+        g_pui_image,
+        "Sce.PlayStation.PUI.UI2",
+        "UIFont");
+    if (!klass)
+        return nullptr;
+
+    MonoObject* boxed = mono_object_new_(g_domain, klass);
+    if (!boxed)
+        return nullptr;
+
+    void* real = mono_object_unbox_(boxed);
+    MonoMethod* ctor = mono_class_get_method_from_name_(klass, ".ctor", 3);
+    void* thunk = ctor ? mono_compile_method_(ctor) : nullptr;
+    if (!real || !thunk)
+        return nullptr;
+
+    auto fn = reinterpret_cast<void (*)(void*, int, int, int)>(thunk);
+    fn(real, size, 0, 0);
+    return reinterpret_cast<MonoObject*>(real);
+}
+
+MonoObject* create_color(float r, float g, float b, float a) {
+    MonoClass* klass = mono_class_from_name_(
+        g_pui_image,
+        "Sce.PlayStation.PUI",
+        "UIColor");
+    if (!klass)
+        return nullptr;
+
+    MonoObject* boxed = mono_object_new_(g_domain, klass);
+    if (!boxed)
+        return nullptr;
+
+    void* real = mono_object_unbox_(boxed);
+    MonoMethod* ctor = mono_class_get_method_from_name_(klass, ".ctor", 4);
+    void* thunk = ctor ? mono_compile_method_(ctor) : nullptr;
+    if (!real || !thunk)
+        return nullptr;
+
+    auto fn = reinterpret_cast<void (*)(void*, float, float, float, float)>(thunk);
+    fn(real, r, g, b, a);
+    return reinterpret_cast<MonoObject*>(real);
+}
+
+MonoObject* create_label(
+    const char* name,
+    float x,
+    float y,
+    const char* text,
+    MonoObject* font,
+    int horizontal_alignment,
+    float r,
+    float g,
+    float b,
+    float a) {
+
+    MonoClass* klass = mono_class_from_name_(
+        g_pui_image,
+        "Sce.PlayStation.PUI.UI2",
+        "Label");
+    if (!klass)
+        return nullptr;
+
+    MonoObject* label = mono_object_new_(g_domain, klass);
+    if (!label)
+        return nullptr;
+
+    mono_runtime_object_init_(label);
+
+    MonoString* mono_name = mono_string_new_(g_domain, name);
+    MonoString* mono_text = mono_string_new_(g_domain, text);
+    MonoObject* color = create_color(r, g, b, a);
+
+    bool ok = true;
+    ok &= set_property_direct(klass, label, "Name", mono_name);
+    ok &= set_property_direct(klass, label, "X", x);
+    ok &= set_property_direct(klass, label, "Y", y);
+    ok &= set_property_direct(klass, label, "Text", mono_text);
+    ok &= set_property_object(klass, label, "Font", font);
+    ok &= set_property_direct(
+        klass, label, "HorizontalAlignment", horizontal_alignment);
+    ok &= set_property_direct(klass, label, "VerticalAlignment", 0);
+    ok &= set_property_object(klass, label, "TextColor", color);
+    ok &= set_property_direct(klass, label, "FitWidthToText", true);
+    ok &= set_property_direct(klass, label, "FitHeightToText", true);
+
+    return ok ? label : nullptr;
+}
+
+MonoObject* find_widget(MonoObject* root, const char* id) {
+    MonoClass* klass = mono_class_from_name_(
+        g_pui_image,
+        "Sce.PlayStation.PUI.UI2",
+        "Widget");
+    MonoMethod* method = klass
+        ? mono_class_get_method_from_name_(klass, "FindWidgetByName", 1)
+        : nullptr;
+    void* thunk = method ? mono_compile_method_(method) : nullptr;
+    if (!root || !thunk)
+        return nullptr;
+
+    MonoString* name = mono_string_new_(g_domain, id);
+    auto fn = reinterpret_cast<MonoObject* (*)(MonoObject*, MonoString*)>(thunk);
+    return fn(root, name);
+}
+
+bool append_child(MonoObject* root, MonoObject* child) {
+    MonoClass* klass = mono_class_from_name_(
+        g_pui_image,
+        "Sce.PlayStation.PUI.UI2",
+        "Widget");
+    MonoMethod* method = klass
+        ? mono_class_get_method_from_name_(klass, "AppendChild", 1)
+        : nullptr;
+    if (!method || !root || !child)
+        return false;
+
+    void* args[1] = {child};
+    MonoObject* exception = nullptr;
+    mono_runtime_invoke_(method, root, args, &exception);
+    return exception == nullptr;
+}
+
+bool set_label_text(MonoObject* label, const char* text) {
+    if (!label)
+        return false;
+
+    MonoClass* klass = mono_class_from_name_(
+        g_pui_image,
+        "Sce.PlayStation.PUI.UI2",
+        "Label");
+    MonoString* mono_text = mono_string_new_(g_domain, text);
+    return set_property_direct(klass, label, "Text", mono_text);
+}
+
+bool apply_packet_on_render(const WirePacket& packet) {
+    const auto decoded = decode_wire_packet(packet);
+    if (!decoded)
+        return false;
+
+    const OverlayFrame& frame = *decoded;
+    MonoObject* root = get_root_widget();
+    if (!root) {
+        static std::uint64_t last_logged_sequence = 0;
+        if (last_logged_sequence != packet.sequence) {
+            last_logged_sequence = packet.sequence;
+            log_line("UI root unavailable seq=%llu",
+                     static_cast<unsigned long long>(packet.sequence));
+        }
+        return false;
+    }
+
+    MonoObject* label = managed_target(g_label_handle);
+    MonoObject* value = managed_target(g_value_handle);
+
+    if (!label)
+        label = find_widget(root, kLabelId);
+    if (!value)
+        value = find_widget(root, kValueId);
+
+    if (!label || !value) {
+        MonoObject* font = create_font(frame.config.font_size);
+        if (!font) {
+            log_line("UIFont create failed");
+            return false;
+        }
+
+        const float x = frame.anchor.x;
+        const float y = frame.anchor.y;
+        const float value_x =
+            x + static_cast<float>(frame.config.font_size) * 2.7f;
+
+        if (!label) {
+            label = create_label(
+                kLabelId,
+                x,
+                y,
+                "FPS:",
+                font,
+                1,
+                0.702f,
+                0.400f,
+                1.000f,
+                1.000f);
+            if (label && !append_child(root, label))
+                label = nullptr;
+        }
+
+        if (!value) {
+            value = create_label(
+                kValueId,
+                value_x,
+                y,
+                "Loading",
+                font,
+                0,
+                1.0f,
+                1.0f,
+                1.0f,
+                1.0f);
+            if (value && !append_child(root, value))
+                value = nullptr;
+        }
+
+        log_line(
+            "widgets create seq=%llu label=%p value=%p font=%d x=%.1f y=%.1f",
+            static_cast<unsigned long long>(packet.sequence),
+            static_cast<void*>(label),
+            static_cast<void*>(value),
+            frame.config.font_size,
+            x,
+            y);
+    }
+
+    if (!label || !value)
+        return false;
+
+    if (!replace_managed_handle(g_label_handle, label) ||
+        !replace_managed_handle(g_value_handle, value)) {
+        log_line(
+            "widget GC handle failed label=%u value=%u",
+            g_label_handle,
+            g_value_handle);
+        return false;
+    }
+
+    char text[32]{};
+    if (frame.loading)
+        std::snprintf(text, sizeof(text), "Loading");
+    else
+        std::snprintf(text, sizeof(text), "%d", frame.fps);
+    return set_label_text(value, text);
+}
+
+void apply_latest_state_on_render() {
+    if (!g_runtime_ready.load() || !g_have_packet.load())
+        return;
+
+    const std::uint64_t sequence = g_sequence.load();
+    if (sequence == g_applied_sequence.load())
+        return;
+
+    WirePacket packet{};
+    pthread_mutex_lock(&g_packet_lock);
+    packet = g_packet;
+    pthread_mutex_unlock(&g_packet_lock);
+
+    if (packet.sequence != sequence || !decode_wire_packet(packet))
+        return;
+
+    if (apply_packet_on_render(packet))
+        g_applied_sequence.store(packet.sequence);
+}
+
+void application_update_hook(MonoObject* instance) {
+    apply_latest_state_on_render();
+
+    if (g_application_update_original)
+        g_application_update_original(instance);
+}
+
+bool install_etahen_update_hook(MonoClass* application_class) {
+    MonoMethod* update = application_class
+        ? mono_class_get_method_from_name_(
+              application_class,
+              "Update",
+              0)
+        : nullptr;
+    auto* address = update
+        ? static_cast<std::uint8_t*>(mono_compile_method_(update))
+        : nullptr;
+    if (!address) {
+        log_line("Application.Update compile failed");
+        return false;
+    }
+
+    static constexpr std::uint8_t kEtaHenJumpPrefix[6] = {
+        0xff, 0x25, 0x00, 0x00, 0x00, 0x00,
+    };
+    if (std::memcmp(
+            address,
+            kEtaHenJumpPrefix,
+            sizeof(kEtaHenJumpPrefix)) != 0) {
+        log_line(
+            "Application.Update etaHEN hook unavailable bytes=%02x%02x%02x%02x%02x%02x",
+            address[0],
+            address[1],
+            address[2],
+            address[3],
+            address[4],
+            address[5]);
+        return false;
+    }
+
+    constexpr std::size_t kJumpSize = 14;
+    auto* trampoline = reinterpret_cast<std::uint8_t*>(
+        &commonfps_update_trampoline);
+    std::memcpy(trampoline, address, kJumpSize);
+    __builtin___clear_cache(
+        reinterpret_cast<char*>(trampoline),
+        reinterpret_cast<char*>(trampoline + kJumpSize));
+
+    std::uint64_t previous_destination = 0;
+    std::memcpy(
+        &previous_destination,
+        address + sizeof(kEtaHenJumpPrefix),
+        sizeof(previous_destination));
+
+    g_application_update_original =
+        reinterpret_cast<application_update_t>(trampoline);
+
+    const std::uint64_t new_destination =
+        reinterpret_cast<std::uint64_t>(&application_update_hook);
+    std::memcpy(
+        address + sizeof(kEtaHenJumpPrefix),
+        &new_destination,
+        sizeof(new_destination));
+    __builtin___clear_cache(
+        reinterpret_cast<char*>(address),
+        reinterpret_cast<char*>(address + kJumpSize));
+
+    log_line(
+        "Application.Update chain online method=%p previous=%p hook=%p",
+        static_cast<void*>(address),
+        reinterpret_cast<void*>(previous_destination),
+        reinterpret_cast<void*>(new_destination));
+    return true;
+}
+
+} // namespace
+
+bool initialize_runtime() {
+    if (g_runtime_ready.load())
+        return true;
+
+    g_domain = mono_get_root_domain_();
+    if (!g_domain) {
+        log_line("root domain failed");
+        return false;
+    }
+    mono_thread_attach_(g_domain);
+
+    g_pui_image = open_image(kPuiDll);
+    MonoImage* app_system = open_image(kAppSystemDll);
+    if (!g_pui_image || !app_system) {
+        log_line("managed image open failed pui=%p app=%p",
+                 static_cast<void*>(g_pui_image),
+                 static_cast<void*>(app_system));
+        return false;
+    }
+
+    MonoClass* layer_manager = mono_class_from_name_(
+        app_system,
+        "Sce.Vsh.ShellUI.AppSystem",
+        "LayerManager");
+    MonoMethod* find_scene = layer_manager
+        ? mono_class_get_method_from_name_(
+              layer_manager,
+              "FindContainerSceneByPath",
+              1)
+        : nullptr;
+    if (!find_scene) {
+        log_line("FindContainerSceneByPath unavailable");
+        return false;
+    }
+
+    MonoDomain* active_domain = mono_domain_get_();
+    MonoString* game_path = mono_string_new_(
+        active_domain ? active_domain : g_domain,
+        "Game");
+    void* find_args[1] = {game_path};
+    MonoObject* game_scene = invoke(find_scene, nullptr, find_args);
+    if (!game_scene) {
+        log_line("Game ContainerScene unavailable");
+        return false;
+    }
+    if (!replace_managed_handle(g_game_scene_handle, game_scene)) {
+        log_line("Game ContainerScene GC handle failed");
+        return false;
+    }
+
+    MonoClass* application_class = mono_class_from_name_(
+        g_pui_image,
+        "Sce.PlayStation.PUI",
+        "Application");
+    if (!application_class || !install_etahen_update_hook(application_class)) {
+        log_line("etaHEN Application.Update chain unavailable");
+        return false;
+    }
+
+    g_runtime_ready.store(true);
+    log_line(
+        "runtime ready pid=%d scene_handle=%u gc_mode=pinned",
+        getpid(),
+        g_game_scene_handle);
+    return true;
+}
+
+bool initialize_receiver() {
+    if (g_receiver_fd >= 0)
+        return true;
+
+    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        log_line("receiver socket failed");
+        return false;
+    }
+
+    int one = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    /*
+     * The hardware-stable v1.0.0 renderer used SO_RCVTIMEO with the exact
+     * timeval {2, 0}.  This lets the render hook stop consuming stale state
+     * after the controller disappears during process teardown while keeping
+     * the injected receiver thread resident.
+     */
+    timeval receive_timeout{};
+    receive_timeout.tv_sec = 2;
+    receive_timeout.tv_usec = 0;
+    if (setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_RCVTIMEO,
+            &receive_timeout,
+            sizeof(receive_timeout)) < 0) {
+        log_line("receiver timeout setup failed");
+        close(fd);
+        return false;
+    }
 
     sockaddr_in addr{};
     addr.sin_family = AF_INET;
@@ -81,20 +737,45 @@ void* receiver_thread(void*) {
             fd,
             reinterpret_cast<sockaddr*>(&addr),
             sizeof(addr)) < 0) {
+        log_line("receiver bind failed port=%u", kDefaultIpcPort);
         close(fd);
-        return nullptr;
+        return false;
     }
 
-    while (g_running.load()) {
-        WirePacket packet{};
+    g_receiver_fd = fd;
+    log_line(
+        "receiver ready port=%u mode=persistent-main-thread "
+        "timeout_ms=2000 stale=1",
+        kDefaultIpcPort);
+    return true;
+}
 
+[[noreturn]] void run_receiver_loop() {
+    for (;;) {
+        WirePacket packet{};
         const ssize_t n = recv(
-            fd,
+            g_receiver_fd,
             &packet,
             sizeof(packet),
             0);
+        if (n != static_cast<ssize_t>(sizeof(packet))) {
+            if (n < 0) {
+                /*
+                 * Match v1.0.0's timeout behavior: invalidate the last
+                 * controller state, but never close, unhook or return.
+                 * A later valid packet makes the renderer live again.
+                 */
+                g_have_packet.store(false);
+                usleep(10000);
+            }
+            continue;
+        }
 
-        if (n != static_cast<ssize_t>(sizeof(packet)))
+        /*
+         * TEST8 proved that returning the injected renderer thread can KP.
+         * A stale shutdown packet is deliberately ignored in TEST13.
+         */
+        if (is_shutdown_wire_packet(packet))
             continue;
 
         if (packet.magic != kWireMagic ||
@@ -110,131 +791,6 @@ void* receiver_thread(void*) {
         g_sequence.store(packet.sequence);
         g_have_packet.store(true);
     }
-
-    close(fd);
-    return nullptr;
-}
-
-} // namespace
-
-bool initialize_receiver() {
-    if (g_running.exchange(true))
-        return true;
-
-    if (pthread_create(
-            &g_thread,
-            nullptr,
-            receiver_thread,
-            nullptr) != 0) {
-        g_running.store(false);
-        return false;
-    }
-
-    pthread_detach(g_thread);
-    return true;
-}
-
-void shutdown_receiver() {
-    g_running.store(false);
-}
-
-void apply_latest_state() {
-    static std::uint64_t applied_sequence = 0;
-
-    if (!g_have_packet.load())
-        return;
-
-    const std::uint64_t sequence = g_sequence.load();
-    if (sequence == applied_sequence)
-        return;
-
-    WirePacket packet{};
-    pthread_mutex_lock(&g_packet_lock);
-    packet = g_packet;
-    pthread_mutex_unlock(&g_packet_lock);
-
-    const auto decoded = decode_wire_packet(packet);
-    if (!decoded)
-        return;
-
-    const OverlayFrame& frame = *decoded;
-
-    MonoObject* root =
-        Get_Property<MonoObject*>(
-            pui_img,
-            "Sce.PlayStation.PUI.UI2",
-            "Scene",
-            Game,
-            "RootWidget");
-
-    if (!root)
-        return;
-
-    /*
-     * Recreate both widgets only when a state packet changes.
-     * The packet rate is ~1 Hz, so this avoids any accumulating cursor state
-     * and uses only PUI primitives already demonstrated in etaHEN source.
-     */
-    remove_widget(root, kLabelId);
-    remove_widget(root, kValueId);
-
-    MonoObject* font =
-        CreateUIFont(frame.config.font_size, 0, 0);
-
-    if (!font)
-        return;
-
-    const float x = frame.anchor.x;
-    const float y = frame.anchor.y;
-
-    /*
-     * Public v1.0.0 color:
-     * #B366FF ~= (0.702, 0.400, 1.000, 1.000)
-     */
-    MonoObject* label =
-        CreateLabel(
-            kLabelId,
-            x,
-            y,
-            "FPS:",
-            font,
-            1,
-            0,
-            0.702f,
-            0.400f,
-            1.000f,
-            1.000f);
-
-    char value_text[32]{};
-    if (frame.loading)
-        std::snprintf(value_text, sizeof(value_text), "loading");
-    else
-        std::snprintf(value_text, sizeof(value_text), "%d", frame.fps);
-
-    const float value_x =
-        x + static_cast<float>(frame.config.font_size) * 2.7f;
-
-    MonoObject* value =
-        CreateLabel(
-            kValueId,
-            value_x,
-            y,
-            value_text,
-            font,
-            0,
-            0,
-            1.0f,
-            1.0f,
-            1.0f,
-            1.0f);
-
-    if (label)
-        Widget_Append_Child(root, label);
-
-    if (value)
-        Widget_Append_Child(root, value);
-
-    applied_sequence = sequence;
 }
 
 } // namespace common_fps::ps5::shellui

--- a/src/ps5/shellui_payload/commonfps_shellui.hpp
+++ b/src/ps5/shellui_payload/commonfps_shellui.hpp
@@ -8,16 +8,17 @@
 #pragma once
 
 #include "common_fps/wire.hpp"
+#include <cstdarg>
 
 namespace common_fps::ps5::shellui {
 
-bool initialize_receiver();
-void shutdown_receiver();
+/* Resolve the already-loaded ShellUI Mono runtime and PUI assemblies. */
+bool initialize_runtime();
 
-/*
- * Call from a ShellUI-safe update/render context.
- * It applies the newest packet only when sequence changes.
- */
-void apply_latest_state();
+/* Bind the loopback UDP receiver used by the controller. */
+bool initialize_receiver();
+
+/* Remain blocked on IPC for the complete SceShellUI process lifetime. */
+[[noreturn]] void run_receiver_loop();
 
 } // namespace common_fps::ps5::shellui

--- a/src/ps5/shellui_payload/commonfps_shellui_entry.cpp
+++ b/src/ps5/shellui_payload/commonfps_shellui_entry.cpp
@@ -1,40 +1,108 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "commonfps_shellui.hpp"
-#include "HookedFuncs.hpp"
 
+#include <cstdio>
 #include <unistd.h>
-
-MonoImage* pui_img = nullptr;
-MonoObject* Game = nullptr;
 
 namespace {
 
-bool mono_context_ready()
-{
-    return Root_Domain != nullptr &&
-           pui_img != nullptr &&
-           Game != nullptr &&
-           mono_class_from_name != nullptr &&
-           mono_class_get_property_from_name != nullptr &&
-           mono_property_get_get_method != nullptr &&
-           mono_compile_method != nullptr &&
-           mono_string_new != nullptr;
+constexpr const char* kMarker = "/system_tmp/commonfps_shellui.pid";
+constexpr const char* kLog = "/data/CommonFPS_v110_shellui.log";
+
+void write_online_marker() {
+    FILE* fp = std::fopen(kMarker, "w");
+    if (!fp)
+        return;
+    std::fprintf(fp, "%d\n", getpid());
+    std::fclose(fp);
 }
 
-}
-
-int main(int, const char**)
-{
-    using namespace common_fps::ps5::shellui;
-
-    if (!initialize_receiver())
-        return 1;
-
-    for (;;) {
-        if (mono_context_ready())
-            apply_latest_state();
-
-        usleep(16000);
+[[noreturn]] void park_renderer_failure(const char* stage) {
+    if (FILE* fp = std::fopen(kLog, "a")) {
+        std::fprintf(
+            fp,
+            "renderer parked stage=%s injected_thread_return=disabled\n",
+            stage);
+        std::fclose(fp);
     }
 
-    return 0;
+    /*
+     * TEST8 demonstrated that returning an injected ShellUI ELF thread can
+     * KP the console. Even a compatibility or socket failure must therefore
+     * remain inert and resident instead of returning through the loader.
+     * TEST13 retains the TEST12 receive timeout/stale-state transition; it
+     * does not reintroduce a remote-thread return path.
+     */
+    for (;;)
+        usleep(1000000);
+}
+
+} // namespace
+
+#if defined(COMMON_FPS_TEST23_PARK_BEFORE_RUNTIME)
+extern "C" {
+/*
+ * Keep the complete renderer reachable in this diagnostic ELF so its image,
+ * imports and relocations remain representative of TEST22. The exported
+ * volatile gate is initialized to zero and is never changed by the controller;
+ * therefore hardware executes only the pre-runtime park branch. Keeping a
+ * runtime-selectable branch prevents --gc-sections from reducing TEST23 to a
+ * different minimal payload.
+ */
+__attribute__((used, visibility("default")))
+volatile int common_fps_test23_runtime_gate = 0;
+}
+#endif
+
+extern "C" __attribute__((noreturn, visibility("default")))
+void* elf_main(void* payload_args) {
+    using namespace common_fps::ps5::shellui;
+
+    /* A shared renderer does not start the PS5 payload CRT in SceShellUI. */
+    (void)payload_args;
+
+    if (FILE* fp = std::fopen(kLog, "w")) {
+        std::fputs(
+            "Common FPS v1.1.0 PARITY TEST13 target-thread bootstrap stack\n",
+            fp);
+        std::fclose(fp);
+    }
+
+#if defined(COMMON_FPS_TEST23_PARK_BEFORE_RUNTIME)
+    if (common_fps_test23_runtime_gate == 0) {
+        /*
+         * Prove that elf_main was entered, then remain resident without any
+         * Mono/PUI lookup, Application.Update patch, GC handle, socket, bind,
+         * recv or widget-tree operation. Returning this injected thread is
+         * permanently forbidden by the TEST8 KP result.
+         */
+        write_online_marker();
+        park_renderer_failure("test23_pre_runtime");
+    }
+#endif
+
+    bool runtime_ready = false;
+    for (int attempt = 0; attempt < 60; ++attempt) {
+        if (initialize_runtime()) {
+            runtime_ready = true;
+            break;
+        }
+        usleep(1000000);
+    }
+
+    if (!runtime_ready)
+        park_renderer_failure("runtime");
+
+    if (!initialize_receiver())
+        park_renderer_failure("receiver");
+
+    write_online_marker();
+    run_receiver_loop();
+
+    __builtin_unreachable();
 }

--- a/src/ps5/stable_elfldr_bridge.c
+++ b/src/ps5/stable_elfldr_bridge.c
@@ -1,0 +1,388 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Source-only bridge around the pinned ps5-payload-dev/shsrv v0.20 loader.
+ * It restores the two loader properties observed in the stable v0.28b
+ * binary:
+ *
+ *   1. temporarily continue ShellUI while the local ELF image is prepared,
+ *      then synchronously stop it before remote writes resume;
+ *   2. resolve R_X86_64_64/R_X86_64_GLOB_DAT imports used by the embedded
+ *      source-built renderer.
+ *
+ * shsrv/elfldr.c remains GPL-3.0-or-later, Copyright (C) 2024 John Tornblom.
+ */
+
+#include <elf.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <ps5/kernel.h>
+
+/*
+ * This intentionally includes the pinned implementation so its private
+ * loader context, payload-args builder and PT_LOAD helper can be reused.
+ * Do not also compile shsrv/elfldr.c as a separate controller source.
+ */
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-compare"
+#endif
+#include "elfldr.c"
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#ifndef DF_1_PIE
+#define DF_1_PIE 0x08000000
+#endif
+
+static bool g_trace_continued = false;
+static bool g_trace_stopped = false;
+static unsigned g_import_resolved = 0;
+static unsigned g_import_unresolved = 0;
+static char g_first_unresolved[128];
+
+static const char* const g_resolve_libraries[] = {
+    "libkernel_sys.sprx",
+    "libkernel.sprx",
+    "libSceLibcInternal.sprx",
+    "libmonosgen-2.0.sprx",
+    "libmonosgen-2.0.0.sprx",
+    "libSceNet.sprx",
+    "libSceSystemService.sprx",
+    "libSceSysmodule.sprx",
+    "libSceUserService.sprx",
+};
+
+static int commonfps_trace_continue(pid_t pid) {
+    if (pt_continue(pid, SIGCONT) != 0)
+        return -1;
+    g_trace_continued = true;
+    return 0;
+}
+
+static int commonfps_trace_stop(pid_t pid) {
+    if (!g_trace_continued || g_trace_stopped)
+        return 0;
+    if (kill(pid, SIGSTOP) != 0)
+        return -1;
+    if (waitpid(pid, 0, 0) < 0)
+        return -1;
+    g_trace_stopped = true;
+    return 0;
+}
+
+static intptr_t commonfps_resolve_external(pid_t pid, const char* name) {
+    if (!name || !*name)
+        return 0;
+
+    const size_t count =
+        sizeof(g_resolve_libraries) / sizeof(g_resolve_libraries[0]);
+
+    for (size_t i = 0; i < count; ++i) {
+        uint32_t handle = 0;
+        if (kernel_dynlib_handle(pid, g_resolve_libraries[i], &handle) < 0 ||
+            handle == 0) {
+            continue;
+        }
+
+        const intptr_t address =
+            kernel_dynlib_dlsym(pid, handle, name);
+        if (address != 0)
+            return address;
+    }
+
+    return 0;
+}
+
+static int commonfps_apply_relocations(
+    elfldr_ctx_t* ctx,
+    Elf64_Ehdr* ehdr,
+    Elf64_Shdr* shdr) {
+
+    for (int i = 0; i < ehdr->e_shnum; ++i) {
+        if (shdr[i].sh_type != SHT_RELA || shdr[i].sh_entsize == 0)
+            continue;
+
+        Elf64_Sym* dynsym = NULL;
+        const char* dynstr = NULL;
+        size_t dynsym_count = 0;
+        size_t dynstr_size = 0;
+
+        if (shdr[i].sh_link < ehdr->e_shnum) {
+            Elf64_Shdr* symsec = &shdr[shdr[i].sh_link];
+            if ((symsec->sh_type == SHT_DYNSYM ||
+                 symsec->sh_type == SHT_SYMTAB) &&
+                symsec->sh_entsize == sizeof(Elf64_Sym) &&
+                symsec->sh_link < ehdr->e_shnum) {
+                Elf64_Shdr* strsec = &shdr[symsec->sh_link];
+                if (strsec->sh_type == SHT_STRTAB) {
+                    dynsym = (Elf64_Sym*)(ctx->elf + symsec->sh_offset);
+                    dynsym_count = symsec->sh_size / sizeof(Elf64_Sym);
+                    dynstr = (const char*)(ctx->elf + strsec->sh_offset);
+                    dynstr_size = strsec->sh_size;
+                }
+            }
+        }
+
+        Elf64_Rela* rela = (Elf64_Rela*)(ctx->elf + shdr[i].sh_offset);
+        const size_t count = shdr[i].sh_size / sizeof(Elf64_Rela);
+
+        for (size_t j = 0; j < count; ++j) {
+            const uint32_t type = (uint32_t)ELF64_R_TYPE(rela[j].r_info);
+            const uint32_t sym_index =
+                (uint32_t)ELF64_R_SYM(rela[j].r_info);
+            intptr_t* location =
+                (intptr_t*)((uint8_t*)ctx->base_mirror + rela[j].r_offset);
+
+            if (type == R_X86_64_RELATIVE) {
+                *location = ctx->base_addr + rela[j].r_addend;
+                continue;
+            }
+
+            if (type == R_X86_64_NONE)
+                continue;
+
+            if (type != R_X86_64_64 && type != R_X86_64_GLOB_DAT)
+                return -1;
+
+            if (!dynsym || !dynstr || sym_index >= dynsym_count)
+                return -1;
+
+            const Elf64_Sym* symbol = &dynsym[sym_index];
+            if (symbol->st_name >= dynstr_size)
+                return -1;
+
+            const char* name = dynstr + symbol->st_name;
+            intptr_t resolved = 0;
+
+            if (symbol->st_shndx == SHN_ABS) {
+                resolved = symbol->st_value;
+            } else if (symbol->st_shndx != SHN_UNDEF) {
+                resolved = ctx->base_addr + symbol->st_value;
+            } else {
+                resolved = commonfps_resolve_external(ctx->pid, name);
+                if (resolved == 0) {
+                    ++g_import_unresolved;
+                    if (g_first_unresolved[0] == '\0') {
+                        strncpy(
+                            g_first_unresolved,
+                            name,
+                            sizeof(g_first_unresolved) - 1);
+                        g_first_unresolved[
+                            sizeof(g_first_unresolved) - 1] = '\0';
+                    }
+                    return -1;
+                }
+                ++g_import_resolved;
+            }
+
+            *location = resolved + rela[j].r_addend;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * This loader is intentionally narrower than shsrv's generic payload loader.
+ * The embedded renderer must be a true shared object whose exported elf_main
+ * lies in an executable PT_LOAD.  In particular, a PIE payload would enter
+ * through its private _start/CRT path and leave a second payload runtime
+ * resident inside SceShellUI -- the last major structural mismatch with the
+ * stable v1.0.0 overlay.
+ */
+static int commonfps_validate_shared_renderer(
+    const uint8_t* elf,
+    const Elf64_Ehdr* ehdr,
+    const Elf64_Phdr* phdr) {
+
+    if (ehdr->e_type != ET_DYN || ehdr->e_machine != EM_X86_64 ||
+        ehdr->e_phentsize != sizeof(Elf64_Phdr) || ehdr->e_phnum == 0) {
+        return -1;
+    }
+
+    bool entry_is_executable = false;
+    bool have_load = false;
+
+    for (int i = 0; i < ehdr->e_phnum; ++i) {
+        const Elf64_Phdr* segment = &phdr[i];
+
+        if (segment->p_type == PT_INTERP)
+            return -1;
+
+        if (segment->p_type == PT_LOAD) {
+            have_load = true;
+            if ((segment->p_flags & PF_X) != 0 &&
+                ehdr->e_entry >= segment->p_vaddr &&
+                ehdr->e_entry - segment->p_vaddr < segment->p_memsz) {
+                entry_is_executable = true;
+            }
+            continue;
+        }
+
+        if (segment->p_type != PT_DYNAMIC)
+            continue;
+
+        const Elf64_Dyn* dynamic =
+            (const Elf64_Dyn*)(elf + segment->p_offset);
+        const size_t count = segment->p_filesz / sizeof(Elf64_Dyn);
+        for (size_t j = 0; j < count; ++j) {
+            if (dynamic[j].d_tag == DT_NULL)
+                break;
+            if (dynamic[j].d_tag == DT_FLAGS_1 &&
+                (dynamic[j].d_un.d_val & DF_1_PIE) != 0) {
+                return -1;
+            }
+        }
+    }
+
+    return have_load && entry_is_executable ? 0 : -1;
+}
+
+intptr_t commonfps_stable_elfldr_load(pid_t pid, uint8_t* elf) {
+    Elf64_Ehdr* ehdr = (Elf64_Ehdr*)elf;
+    Elf64_Phdr* phdr = (Elf64_Phdr*)(elf + ehdr->e_phoff);
+    Elf64_Shdr* shdr = (Elf64_Shdr*)(elf + ehdr->e_shoff);
+    elfldr_ctx_t ctx = {.elf = elf, .pid = pid};
+
+    g_trace_continued = false;
+    g_trace_stopped = false;
+    g_import_resolved = 0;
+    g_import_unresolved = 0;
+    memset(g_first_unresolved, 0, sizeof(g_first_unresolved));
+
+    if (ehdr->e_ident[0] != 0x7f || ehdr->e_ident[1] != 'E' ||
+        ehdr->e_ident[2] != 'L' || ehdr->e_ident[3] != 'F' ||
+        ehdr->e_ident[EI_CLASS] != ELFCLASS64 ||
+        ehdr->e_ident[EI_DATA] != ELFDATA2LSB ||
+        commonfps_validate_shared_renderer(elf, ehdr, phdr) != 0) {
+        return 0;
+    }
+
+    size_t min_vaddr = (size_t)-1;
+    size_t max_vaddr = 0;
+    int error = 0;
+
+    for (int i = 0; i < ehdr->e_phnum; ++i) {
+        if (phdr[i].p_type != PT_LOAD)
+            continue;
+        if (phdr[i].p_vaddr < min_vaddr)
+            min_vaddr = phdr[i].p_vaddr;
+        if (max_vaddr < phdr[i].p_vaddr + phdr[i].p_memsz)
+            max_vaddr = phdr[i].p_vaddr + phdr[i].p_memsz;
+    }
+
+    min_vaddr = TRUNC_PG(min_vaddr);
+    max_vaddr = ROUND_PG(max_vaddr);
+    ctx.base_size = max_vaddr - min_vaddr;
+
+    int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+    const int prot = PROT_READ | PROT_WRITE;
+    ctx.base_addr = 0;
+
+    ctx.base_addr = pt_mmap(
+        pid,
+        ctx.base_addr,
+        ctx.base_size,
+        prot,
+        flags,
+        -1,
+        0);
+    if (ctx.base_addr == -1)
+        return 0;
+
+    if (commonfps_trace_continue(pid) != 0)
+        error = -1;
+
+    ctx.base_mirror = mmap(
+        0,
+        ctx.base_size,
+        prot,
+        MAP_PRIVATE | MAP_ANONYMOUS,
+        -1,
+        0);
+    if (ctx.base_mirror == MAP_FAILED)
+        error = -1;
+
+    for (int i = 0; i < ehdr->e_phnum && !error; ++i) {
+        if (phdr[i].p_type == PT_LOAD)
+            error = pt_load(&ctx, &phdr[i]);
+    }
+
+    if (!error)
+        error = commonfps_apply_relocations(&ctx, ehdr, shdr);
+
+    if (commonfps_trace_stop(pid) != 0)
+        error = -1;
+
+    if (!error &&
+        pt_copyin(ctx.pid, ctx.base_mirror, ctx.base_addr, ctx.base_size) != 0) {
+        error = -1;
+    }
+
+    for (int i = 0; i < ehdr->e_phnum && !error; ++i) {
+        if (phdr[i].p_type != PT_LOAD || phdr[i].p_memsz == 0)
+            continue;
+
+        const intptr_t address = ctx.base_addr + phdr[i].p_vaddr;
+        const size_t size = ROUND_PG(phdr[i].p_memsz);
+        const int segment_prot = PFLAGS(phdr[i].p_flags);
+
+        if (phdr[i].p_flags & PF_X) {
+            if (kernel_mprotect(pid, address, size, segment_prot) != 0)
+                error = -1;
+        } else if (pt_mprotect(pid, address, size, segment_prot) != 0) {
+            error = -1;
+        }
+    }
+
+    if (!error && pt_msync(pid, ctx.base_addr, ctx.base_size, MS_SYNC) != 0)
+        error = -1;
+
+    if (ctx.base_mirror != MAP_FAILED)
+        munmap(ctx.base_mirror, ctx.base_size);
+
+    if (error) {
+        if (g_trace_continued && !g_trace_stopped)
+            (void)commonfps_trace_stop(pid);
+        (void)pt_munmap(pid, ctx.base_addr, ctx.base_size);
+        return 0;
+    }
+
+    return ctx.base_addr + ehdr->e_entry;
+}
+
+intptr_t commonfps_stable_elfldr_payload_args(pid_t pid) {
+    return elfldr_payload_args(pid);
+}
+
+int commonfps_stable_trace_continue_seen(void) {
+    return g_trace_continued ? 1 : 0;
+}
+
+int commonfps_stable_trace_stop_seen(void) {
+    return g_trace_stopped ? 1 : 0;
+}
+
+unsigned commonfps_stable_import_resolved_count(void) {
+    return g_import_resolved;
+}
+
+unsigned commonfps_stable_import_unresolved_count(void) {
+    return g_import_unresolved;
+}
+
+const char* commonfps_stable_first_unresolved(void) {
+    return g_first_unresolved;
+}

--- a/src/ps5/stable_sampler/proc_rw_v960.cpp
+++ b/src/ps5/stable_sampler/proc_rw_v960.cpp
@@ -1,0 +1,251 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "proc_rw_v960.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <sys/sysctl.h>
+
+extern "C" {
+#include <ps5/kernel.h>
+}
+
+namespace common_fps::ps5::stable_sampler {
+namespace {
+
+constexpr std::uint32_t kFw960 = 0x09600000U;
+constexpr std::uintptr_t kAllprocFromKdata = 0x02755D50ULL;
+constexpr std::uintptr_t kProcPid = 0xBCULL;
+constexpr std::uintptr_t kProcVmspace = 0x200ULL;
+constexpr std::uintptr_t kProcNext = 0x00ULL;
+constexpr std::uintptr_t kVmspacePmap = 0x1D8ULL;
+constexpr std::uintptr_t kPmapPml4Virtual = 0x20ULL;
+constexpr std::uintptr_t kPmapPml4Physical = 0x28ULL;
+constexpr std::uintptr_t kFixedDmapBase = 0xFFFF873B00000000ULL;
+
+constexpr std::uint64_t kPresent = 1ULL;
+constexpr std::uint64_t kPageSizeBit = 1ULL << 7;
+constexpr std::uint64_t kMask4K = 0x000FFFFFFFFFF000ULL;
+constexpr std::uint64_t kMask2M = 0x000FFFFFFFE00000ULL;
+constexpr std::uint64_t kMask1G = 0x000FFFFFC0000000ULL;
+
+constexpr std::size_t kPage4K = 0x1000ULL;
+constexpr std::size_t kPage2M = 0x200000ULL;
+constexpr std::size_t kPage1G = 0x40000000ULL;
+constexpr unsigned kMaxProcWalk = 1024U;
+
+std::uintptr_t g_dmap_base = 0;
+
+bool read_kernel(
+    std::uintptr_t address,
+    void* out,
+    std::size_t size) noexcept {
+    return address != 0 && out != nullptr && size != 0 &&
+        kernel_copyout(address, out, size) == 0;
+}
+
+template <typename T>
+bool read_kernel_value(std::uintptr_t address, T& out) noexcept {
+    out = {};
+    return read_kernel(address, &out, sizeof(out));
+}
+
+std::uintptr_t find_proc(pid_t pid) noexcept {
+    if (pid <= 0 || !firmware_is_960() || KERNEL_ADDRESS_DATA_BASE == 0)
+        return 0;
+
+    std::uintptr_t current = 0;
+    if (!read_kernel_value(
+            static_cast<std::uintptr_t>(KERNEL_ADDRESS_DATA_BASE) +
+                kAllprocFromKdata,
+            current)) {
+        return 0;
+    }
+
+    for (unsigned i = 0; current != 0 && i < kMaxProcWalk; ++i) {
+        std::uint32_t candidate_pid = 0;
+        if (!read_kernel_value(current + kProcPid, candidate_pid))
+            return 0;
+
+        if (candidate_pid == static_cast<std::uint32_t>(pid))
+            return current;
+
+        std::uintptr_t next = 0;
+        if (!read_kernel_value(current + kProcNext, next) || next == current)
+            return 0;
+        current = next;
+    }
+
+    return 0;
+}
+
+std::uintptr_t choose_dmap(
+    std::uintptr_t pml4_virtual,
+    std::uintptr_t pml4_physical) noexcept {
+
+    if (g_dmap_base != 0)
+        return g_dmap_base;
+
+    if (pml4_virtual > pml4_physical &&
+        pml4_physical < (1ULL << 40)) {
+        const std::uintptr_t candidate = pml4_virtual - pml4_physical;
+        if ((candidate >> 48) != 0)
+            g_dmap_base = candidate;
+    }
+
+    if (g_dmap_base == 0)
+        g_dmap_base = kFixedDmapBase;
+
+    return g_dmap_base;
+}
+
+bool read_page_entry(std::uintptr_t address, std::uint64_t& entry) noexcept {
+    return read_kernel_value(address, entry) && (entry & kPresent) != 0;
+}
+
+} // namespace
+
+std::uint32_t firmware_sdk_version() noexcept {
+    std::uint32_t sdk = 0;
+    std::size_t sdk_len = sizeof(sdk);
+    if (sysctlbyname("kern.sdk_version", &sdk, &sdk_len, nullptr, 0) != 0 ||
+        sdk_len != sizeof(sdk)) {
+        return 0;
+    }
+    return sdk;
+}
+
+bool firmware_is_960() noexcept {
+    return (firmware_sdk_version() & 0xFFFF0000U) == kFw960;
+}
+
+std::uintptr_t dmap_base() noexcept {
+    return g_dmap_base != 0 ? g_dmap_base : kFixedDmapBase;
+}
+
+std::uintptr_t translate(
+    pid_t pid,
+    std::uintptr_t remote,
+    std::size_t* page_size) noexcept {
+
+    if (page_size)
+        *page_size = 0;
+
+    const std::uintptr_t proc = find_proc(pid);
+    if (proc == 0)
+        return 0;
+
+    std::uintptr_t vmspace = 0;
+    std::uintptr_t pmap = 0;
+    std::uintptr_t pml4_virtual = 0;
+    std::uintptr_t pml4_physical = 0;
+
+    if (!read_kernel_value(proc + kProcVmspace, vmspace) || vmspace == 0)
+        return 0;
+    if (!read_kernel_value(vmspace + kVmspacePmap, pmap) || pmap == 0)
+        return 0;
+    if (!read_kernel_value(pmap + kPmapPml4Virtual, pml4_virtual) ||
+        pml4_virtual == 0) {
+        return 0;
+    }
+    if (!read_kernel_value(pmap + kPmapPml4Physical, pml4_physical) ||
+        pml4_physical == 0) {
+        return 0;
+    }
+
+    const std::uintptr_t dmap = choose_dmap(pml4_virtual, pml4_physical);
+    if (dmap == 0)
+        return 0;
+
+    const std::size_t pml4_index = (remote >> 39) & 0x1FFULL;
+    const std::size_t pdpt_index = (remote >> 30) & 0x1FFULL;
+    const std::size_t pd_index = (remote >> 21) & 0x1FFULL;
+    const std::size_t pt_index = (remote >> 12) & 0x1FFULL;
+
+    std::uint64_t pml4e = 0;
+    if (!read_page_entry(pml4_virtual + pml4_index * 8ULL, pml4e))
+        return 0;
+
+    std::uint64_t pdpte = 0;
+    if (!read_page_entry(
+            dmap + (pml4e & kMask4K) + pdpt_index * 8ULL,
+            pdpte)) {
+        return 0;
+    }
+
+    if ((pdpte & kPageSizeBit) != 0) {
+        if (page_size)
+            *page_size = kPage1G;
+        return static_cast<std::uintptr_t>(pdpte & kMask1G) |
+            (remote & (kPage1G - 1ULL));
+    }
+
+    std::uint64_t pde = 0;
+    if (!read_page_entry(
+            dmap + (pdpte & kMask4K) + pd_index * 8ULL,
+            pde)) {
+        return 0;
+    }
+
+    if ((pde & kPageSizeBit) != 0) {
+        if (page_size)
+            *page_size = kPage2M;
+        return static_cast<std::uintptr_t>(pde & kMask2M) |
+            (remote & (kPage2M - 1ULL));
+    }
+
+    std::uint64_t pte = 0;
+    if (!read_page_entry(
+            dmap + (pde & kMask4K) + pt_index * 8ULL,
+            pte)) {
+        return 0;
+    }
+
+    if (page_size)
+        *page_size = kPage4K;
+    return static_cast<std::uintptr_t>(pte & kMask4K) |
+        (remote & (kPage4K - 1ULL));
+}
+
+bool proc_read(
+    pid_t pid,
+    std::uintptr_t remote,
+    void* local,
+    std::size_t size) noexcept {
+
+    if (size == 0)
+        return true;
+    if (pid <= 0 || remote == 0 || local == nullptr)
+        return false;
+
+    auto* output = static_cast<std::uint8_t*>(local);
+    std::size_t remaining = size;
+
+    while (remaining != 0) {
+        std::size_t page_size = 0;
+        const std::uintptr_t physical = translate(pid, remote, &page_size);
+        if (physical == 0 || page_size == 0)
+            return false;
+
+        const std::size_t page_offset =
+            static_cast<std::size_t>(remote & (page_size - 1ULL));
+        const std::size_t chunk =
+            std::min(remaining, page_size - page_offset);
+
+        if (kernel_copyout(dmap_base() + physical, output, chunk) != 0)
+            return false;
+
+        remote += chunk;
+        output += chunk;
+        remaining -= chunk;
+    }
+
+    return true;
+}
+
+} // namespace common_fps::ps5::stable_sampler

--- a/src/ps5/stable_sampler/proc_rw_v960.hpp
+++ b/src/ps5/stable_sampler/proc_rw_v960.hpp
@@ -1,0 +1,35 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <sys/types.h>
+
+namespace common_fps::ps5::stable_sampler {
+
+/*
+ * FW 9.60 DMAP reader reconstructed from the hardware-proven sampler.
+ * It performs read-only game access and never attaches through ptrace/MDBG.
+ */
+[[nodiscard]] bool proc_read(
+    pid_t pid,
+    std::uintptr_t remote,
+    void* local,
+    std::size_t size) noexcept;
+
+[[nodiscard]] std::uintptr_t translate(
+    pid_t pid,
+    std::uintptr_t remote,
+    std::size_t* page_size) noexcept;
+
+[[nodiscard]] std::uintptr_t dmap_base() noexcept;
+[[nodiscard]] std::uint32_t firmware_sdk_version() noexcept;
+[[nodiscard]] bool firmware_is_960() noexcept;
+
+} // namespace common_fps::ps5::stable_sampler

--- a/src/ps5/stable_sampler/process_sysctl.cpp
+++ b/src/ps5/stable_sampler/process_sysctl.cpp
@@ -1,0 +1,134 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "process_sysctl.hpp"
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+namespace common_fps::ps5::stable_sampler {
+namespace {
+
+constexpr long kSysctlSyscall = 202;
+constexpr int kCtlKern = 1;
+constexpr int kKernProc = 14;
+constexpr int kKernProcProc = 8;
+constexpr std::size_t kPidOffset = 72U;
+constexpr std::size_t kTdnameOffset = 447U;
+constexpr char kGameName[] = "eboot.bin";
+
+bool record_name_equals(
+    const std::uint8_t* record,
+    std::size_t record_size) noexcept {
+
+    if (!record || record_size <= kTdnameOffset)
+        return false;
+
+    constexpr std::size_t wanted_size = sizeof(kGameName);
+    const std::size_t available = record_size - kTdnameOffset;
+    return available >= wanted_size &&
+        std::memcmp(record + kTdnameOffset, kGameName, wanted_size) == 0;
+}
+
+} // namespace
+
+ProcessLookupResult find_game_process_sysctl() noexcept {
+    ProcessLookupResult result{};
+    int mib[4] = {
+        kCtlKern,
+        kKernProc,
+        kKernProcProc,
+        0,
+    };
+
+    std::size_t required = 0;
+    result.size_query_rc = static_cast<int>(syscall(
+        kSysctlSyscall,
+        mib,
+        4,
+        nullptr,
+        &required,
+        nullptr,
+        0));
+
+    if (result.size_query_rc != 0 || required == 0) {
+        result.saved_errno = errno;
+        return result;
+    }
+
+    /* Allow the process list to grow between the two sysctl calls. */
+    const std::size_t capacity = required + required / 4U + 4096U;
+    auto* buffer = static_cast<std::uint8_t*>(std::malloc(capacity));
+    if (!buffer) {
+        result.saved_errno = ENOMEM;
+        return result;
+    }
+
+    result.bytes = capacity;
+    result.data_query_rc = static_cast<int>(syscall(
+        kSysctlSyscall,
+        mib,
+        4,
+        buffer,
+        &result.bytes,
+        nullptr,
+        0));
+
+    if (result.data_query_rc != 0 || result.bytes > capacity) {
+        result.saved_errno = errno;
+        std::free(buffer);
+        return result;
+    }
+
+    const pid_t self = getpid();
+    const std::uint8_t* cursor = buffer;
+    const std::uint8_t* const end = buffer + result.bytes;
+
+    while (cursor < end) {
+        const std::size_t remaining =
+            static_cast<std::size_t>(end - cursor);
+        if (remaining < sizeof(int)) {
+            ++result.malformed_records;
+            break;
+        }
+
+        int record_size_signed = 0;
+        std::memcpy(
+            &record_size_signed,
+            cursor,
+            sizeof(record_size_signed));
+
+        if (record_size_signed <= 0 ||
+            static_cast<std::size_t>(record_size_signed) > remaining) {
+            ++result.malformed_records;
+            break;
+        }
+
+        ++result.records;
+        const std::size_t record_size =
+            static_cast<std::size_t>(record_size_signed);
+
+        if (record_size >= kPidOffset + sizeof(pid_t) &&
+            record_name_equals(cursor, record_size)) {
+            pid_t candidate = -1;
+            std::memcpy(&candidate, cursor + kPidOffset, sizeof(candidate));
+            if (candidate > 0 && candidate != self)
+                result.pid = candidate;
+        }
+
+        cursor += record_size;
+    }
+
+    std::free(buffer);
+    return result;
+}
+
+} // namespace common_fps::ps5::stable_sampler

--- a/src/ps5/stable_sampler/process_sysctl.hpp
+++ b/src/ps5/stable_sampler/process_sysctl.hpp
@@ -1,0 +1,31 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <sys/types.h>
+
+namespace common_fps::ps5::stable_sampler {
+
+struct ProcessLookupResult {
+    pid_t pid = -1;
+    int size_query_rc = -1;
+    int data_query_rc = -1;
+    int saved_errno = 0;
+    std::size_t bytes = 0;
+    unsigned records = 0;
+    unsigned malformed_records = 0;
+};
+
+/*
+ * FW 9.60 KERN_PROC lookup used by the hardware-proven sampler.
+ * Returns the last non-self process whose tdname is exactly "eboot.bin".
+ */
+[[nodiscard]] ProcessLookupResult find_game_process_sysctl() noexcept;
+
+} // namespace common_fps::ps5::stable_sampler

--- a/src/ps5/stable_sampler/videoout_module.cpp
+++ b/src/ps5/stable_sampler/videoout_module.cpp
@@ -1,0 +1,157 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "videoout_module.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+extern "C" {
+#include <ps5/kernel.h>
+}
+
+namespace common_fps::ps5::stable_sampler {
+namespace {
+
+constexpr char kVideoOutModule[] = "libSceVideoOut.sprx";
+constexpr std::uint64_t kDebuggerAuthId = 0x4800000000000006ULL;
+constexpr std::uintptr_t kAuthIdOffset = 0x58ULL;
+constexpr long kSysDlGetList = 0x217;
+constexpr long kSysDlGetInfo2 = 0x2cd;
+constexpr long kExpectedSizeQueryRc = 12;
+
+constexpr std::size_t kModuleNameLength = 128;
+constexpr std::size_t kSandboxPathLength = 1024;
+constexpr std::size_t kMaxSections = 4;
+constexpr std::size_t kFingerprintLength = 20;
+
+struct ModuleSectionCompat {
+    std::uint64_t vaddr;
+    std::uint32_t size;
+    std::uint32_t prot;
+};
+
+struct ModuleInfoCompat {
+    char filename[kModuleNameLength];
+    std::uint64_t handle;
+    std::uint8_t unknown0[32];
+    std::uint64_t init;
+    std::uint64_t fini;
+    std::uint64_t eh_frame_hdr;
+    std::uint64_t eh_frame_hdr_sz;
+    std::uint64_t eh_frame;
+    std::uint64_t eh_frame_sz;
+    ModuleSectionCompat sections[kMaxSections];
+    std::uint8_t unknown7[1176];
+    std::uint8_t fingerprint[kFingerprintLength];
+    std::uint32_t unknown8;
+    char libname[kModuleNameLength];
+    std::uint32_t unknown9;
+    char sandboxed_path[kSandboxPathLength];
+    std::uint64_t sdk_version;
+};
+
+} // namespace
+
+VideoOutModuleResult find_videoout_module(pid_t pid) noexcept {
+    VideoOutModuleResult result{};
+    if (pid <= 0)
+        return result;
+
+    const std::uintptr_t self_ucred = kernel_get_proc_ucred(getpid());
+    if (self_ucred == 0)
+        return result;
+
+    std::uint64_t saved_auth = 0;
+    if (kernel_copyout(
+            self_ucred + kAuthIdOffset,
+            &saved_auth,
+            sizeof(saved_auth)) != 0) {
+        return result;
+    }
+    result.auth_read = true;
+
+    const std::uint64_t debug_auth = kDebuggerAuthId;
+    if (kernel_copyin(
+            &debug_auth,
+            self_ucred + kAuthIdOffset,
+            sizeof(debug_auth)) != 0) {
+        return result;
+    }
+    result.auth_changed = true;
+
+    result.size_query_rc = syscall(
+        kSysDlGetList,
+        pid,
+        nullptr,
+        0,
+        &result.requested_count);
+
+    if ((result.size_query_rc == 0 ||
+         result.size_query_rc == kExpectedSizeQueryRc) &&
+        result.requested_count > 0 &&
+        result.requested_count < 1024) {
+        auto* handles = static_cast<std::uintptr_t*>(std::calloc(
+            result.requested_count,
+            sizeof(std::uintptr_t)));
+
+        if (handles) {
+            result.returned_count = result.requested_count;
+            result.fill_query_rc = syscall(
+                kSysDlGetList,
+                pid,
+                handles,
+                result.requested_count,
+                &result.returned_count);
+
+            if (result.fill_query_rc == 0 &&
+                result.returned_count <= result.requested_count) {
+                for (std::size_t i = 0;
+                     i < result.returned_count;
+                     ++i) {
+                    ModuleInfoCompat info{};
+                    result.last_info_rc = syscall(
+                        kSysDlGetInfo2,
+                        pid,
+                        1,
+                        handles[i],
+                        &info);
+                    if (result.last_info_rc != 0)
+                        continue;
+
+                    ++result.info_successes;
+                    info.filename[kModuleNameLength - 1] = '\0';
+                    if (std::strcmp(info.filename, kVideoOutModule) == 0 &&
+                        info.sections[0].vaddr != 0) {
+                        result.base = static_cast<std::uintptr_t>(
+                            info.sections[0].vaddr);
+                        break;
+                    }
+                }
+            }
+
+            std::free(handles);
+        }
+    }
+
+    /* Restoring the original Auth ID before DMAP access is mandatory. */
+    result.auth_restore_attempted = true;
+    result.auth_restored = kernel_copyin(
+        &saved_auth,
+        self_ucred + kAuthIdOffset,
+        sizeof(saved_auth)) == 0;
+
+    if (!result.auth_restored)
+        result.base = 0;
+
+    return result;
+}
+
+} // namespace common_fps::ps5::stable_sampler

--- a/src/ps5/stable_sampler/videoout_module.hpp
+++ b/src/ps5/stable_sampler/videoout_module.hpp
@@ -1,0 +1,37 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <sys/types.h>
+
+namespace common_fps::ps5::stable_sampler {
+
+struct VideoOutModuleResult {
+    std::uintptr_t base = 0;
+    bool auth_read = false;
+    bool auth_changed = false;
+    bool auth_restore_attempted = false;
+    bool auth_restored = false;
+    long size_query_rc = -1;
+    long fill_query_rc = -1;
+    long last_info_rc = -1;
+    std::size_t requested_count = 0;
+    std::size_t returned_count = 0;
+    unsigned info_successes = 0;
+};
+
+/*
+ * Resolves libSceVideoOut.sprx with a short self Auth-ID window. The original
+ * Auth ID is restored before this function returns and before any DMAP read.
+ */
+[[nodiscard]] VideoOutModuleResult
+find_videoout_module(pid_t pid) noexcept;
+
+} // namespace common_fps::ps5::stable_sampler

--- a/src/ps5/stable_shellui_injector.cpp
+++ b/src/ps5/stable_shellui_injector.cpp
@@ -1,0 +1,258 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * The control flow is reconstructed from the hardware-proven v0.28b
+ * injector.  Ptrace and payload-args primitives come from the pinned GPL
+ * ps5-payload-dev/shsrv v0.20 source dependency.
+ */
+
+#include "stable_shellui_injector.hpp"
+#include "remote_call.hpp"
+
+#include <csignal>
+#include <cstddef>
+#include <cstdint>
+#include <sys/mman.h>
+#include <unistd.h>
+
+extern "C" {
+#include <ps5/kernel.h>
+#include <ps5/nid.h>
+#include "pt.h"
+
+intptr_t commonfps_stable_elfldr_load(pid_t pid, std::uint8_t* elf);
+intptr_t commonfps_stable_elfldr_payload_args(pid_t pid);
+int commonfps_stable_trace_continue_seen(void);
+int commonfps_stable_trace_stop_seen(void);
+unsigned commonfps_stable_import_resolved_count(void);
+unsigned commonfps_stable_import_unresolved_count(void);
+const char* commonfps_stable_first_unresolved(void);
+}
+
+namespace common_fps::ps5 {
+namespace {
+
+constexpr std::uint64_t kPtraceAuthId = 0x4800000000010003ULL;
+
+using RemotePthreadCreate = int (*)(
+    std::uintptr_t*,
+    const void*,
+    void* (*)(void*),
+    void*);
+
+struct RemoteBootstrapFunctions {
+    void* debug_out = nullptr;
+    void* elf_main = nullptr;
+    void* payload_args = nullptr;
+    RemotePthreadCreate pthread_create_fn = nullptr;
+    int pthread_create_rc = -777;
+    std::uint32_t start_thread = 1;
+};
+
+static_assert(offsetof(RemoteBootstrapFunctions, elf_main) == 0x08);
+static_assert(offsetof(RemoteBootstrapFunctions, payload_args) == 0x10);
+static_assert(offsetof(RemoteBootstrapFunctions, pthread_create_fn) == 0x18);
+static_assert(offsetof(RemoteBootstrapFunctions, pthread_create_rc) == 0x20);
+static_assert(offsetof(RemoteBootstrapFunctions, start_thread) == 0x24);
+static_assert(sizeof(RemoteBootstrapFunctions) == 0x28);
+
+extern "C" __attribute__((used, noinline, section(".commonfps_stager.1")))
+int commonfps_stable_stager(RemoteBootstrapFunctions* functions) {
+    if (functions->start_thread != 0) {
+        std::uintptr_t thread = 0;
+        functions->pthread_create_rc = functions->pthread_create_fn(
+            &thread,
+            nullptr,
+            reinterpret_cast<void* (*)(void*)>(functions->elf_main),
+            functions->payload_args);
+    } else {
+        /*
+         * PARITY TEST25 still exercises the exact target-stack stager call and
+         * INT3/register-restore cycle, but this branch performs no remote
+         * pthread_create and never enters the mapped renderer.
+         */
+        functions->pthread_create_rc = kPthreadCreateSkippedRc;
+    }
+
+    asm volatile("int3");
+    return 0;
+}
+
+extern "C" __attribute__((used, noinline, section(".commonfps_stager.2")))
+int commonfps_stable_stager_end() {
+    return 0;
+}
+
+std::size_t stager_size() noexcept {
+    const auto begin =
+        reinterpret_cast<std::uintptr_t>(&commonfps_stable_stager);
+    const auto end =
+        reinterpret_cast<std::uintptr_t>(&commonfps_stable_stager_end);
+    return end > begin ? static_cast<std::size_t>(end - begin) : 0;
+}
+
+std::uintptr_t resolve_remote(pid_t pid, const char* symbol) noexcept {
+    char nid[12]{};
+    if (!nid_encode(symbol, nid))
+        return 0;
+    return static_cast<std::uintptr_t>(pt_resolve(pid, nid));
+}
+
+} // namespace
+
+StableInjectionResult inject_shellui_stable(
+    pid_t shellui_pid,
+    const std::uint8_t* renderer_elf,
+    std::size_t renderer_size,
+    StableInjectionMode mode) noexcept {
+
+    StableInjectionResult result{};
+    result.thread_start_requested =
+        mode == StableInjectionMode::StartRendererThread;
+    if (shellui_pid <= 0 || !renderer_elf || renderer_size < 64)
+        return result;
+
+    const pid_t self = getpid();
+    const std::uint64_t original_auth = kernel_get_ucred_authid(self);
+    if (original_auth == 0)
+        return result;
+
+    if (kernel_set_ucred_authid(self, kPtraceAuthId) != 0)
+        return result;
+    result.auth_changed = true;
+
+    if (pt_attach(shellui_pid) == 0) {
+        result.attached = true;
+
+        do {
+            const std::uintptr_t pthread_create =
+                resolve_remote(shellui_pid, "pthread_create");
+            if (pthread_create == 0)
+                break;
+
+            const intptr_t entry = commonfps_stable_elfldr_load(
+                shellui_pid,
+                const_cast<std::uint8_t*>(renderer_elf));
+
+            result.trace_continue_seen =
+                commonfps_stable_trace_continue_seen() != 0;
+            result.trace_stop_seen =
+                commonfps_stable_trace_stop_seen() != 0;
+            result.imports_resolved =
+                commonfps_stable_import_resolved_count();
+            result.imports_unresolved =
+                commonfps_stable_import_unresolved_count();
+            result.first_unresolved =
+                commonfps_stable_first_unresolved();
+
+            if (entry <= 0)
+                break;
+            result.elf_loaded = true;
+
+            const intptr_t payload_args =
+                commonfps_stable_elfldr_payload_args(shellui_pid);
+            if (payload_args <= 0)
+                break;
+            result.payload_args_ready = true;
+
+            const std::size_t code_size = stager_size();
+            if (code_size == 0)
+                break;
+
+            const intptr_t remote_stager = pt_mmap(
+                shellui_pid,
+                0,
+                code_size,
+                PROT_READ | PROT_WRITE,
+                MAP_ANONYMOUS | MAP_PRIVATE,
+                -1,
+                0);
+            if (remote_stager <= 0)
+                break;
+
+            if (kernel_mprotect(
+                    shellui_pid,
+                    remote_stager,
+                    code_size,
+                    PROT_READ | PROT_WRITE | PROT_EXEC) != 0) {
+                break;
+            }
+
+            if (pt_copyin(
+                    shellui_pid,
+                    reinterpret_cast<const void*>(&commonfps_stable_stager),
+                    remote_stager,
+                    code_size) != 0) {
+                break;
+            }
+            result.remote_stager_ready = true;
+
+            RemoteBootstrapFunctions functions{};
+            functions.elf_main = reinterpret_cast<void*>(entry);
+            functions.payload_args = reinterpret_cast<void*>(payload_args);
+            functions.pthread_create_fn =
+                reinterpret_cast<RemotePthreadCreate>(pthread_create);
+            functions.start_thread = result.thread_start_requested ? 1U : 0U;
+
+            const intptr_t remote_functions = pt_mmap(
+                shellui_pid,
+                0,
+                sizeof(functions),
+                PROT_READ | PROT_WRITE,
+                MAP_ANONYMOUS | MAP_PRIVATE,
+                -1,
+                0);
+            if (remote_functions <= 0)
+                break;
+
+            if (pt_copyin(
+                    shellui_pid,
+                    &functions,
+                    remote_functions,
+                    sizeof(functions)) != 0) {
+                break;
+            }
+            result.remote_functions_ready = true;
+
+            /*
+             * Exact v1.0.0 pt_call2 parity: change RIP/arguments while
+             * preserving the stopped ShellUI thread's original RSP/RBP.
+             * The stager reaches INT3 before it can return.
+             */
+            result.target_stack_preserved = true;
+            (void)call_until_breakpoint_on_target_stack(
+                shellui_pid,
+                static_cast<std::uintptr_t>(remote_stager),
+                static_cast<std::uint64_t>(remote_functions));
+
+            RemoteBootstrapFunctions readback{};
+            readback.pthread_create_rc = -777;
+            if (pt_copyout(
+                    shellui_pid,
+                    remote_functions,
+                    &readback,
+                    sizeof(readback)) == 0 &&
+                readback.pthread_create_rc != -777) {
+                result.bootstrap_started = true;
+                result.pthread_create_rc = readback.pthread_create_rc;
+                result.pthread_create_ok =
+                    result.thread_start_requested &&
+                    readback.pthread_create_rc == 0;
+            }
+        } while (false);
+
+        result.detached = pt_detach(shellui_pid, 0) == 0;
+        (void)kill(shellui_pid, SIGCONT);
+    }
+
+    if (kernel_set_ucred_authid(self, original_auth) == 0) {
+        result.auth_restored =
+            kernel_get_ucred_authid(self) == original_auth;
+    }
+
+    return result;
+}
+
+} // namespace common_fps::ps5

--- a/src/ps5/stable_shellui_injector.hpp
+++ b/src/ps5/stable_shellui_injector.hpp
@@ -1,0 +1,57 @@
+/*
+ * Common FPS for PS5
+ * Copyright (C) 2026 porhe911
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <sys/types.h>
+
+namespace common_fps::ps5 {
+
+enum class StableInjectionMode : std::uint8_t {
+    StartRendererThread,
+    ExerciseStagerWithoutThread,
+};
+
+inline constexpr int kPthreadCreateSkippedRc = -778;
+
+struct StableInjectionResult {
+    bool auth_changed = false;
+    bool auth_restored = false;
+    bool attached = false;
+    bool elf_loaded = false;
+    bool payload_args_ready = false;
+    bool remote_stager_ready = false;
+    bool remote_functions_ready = false;
+    bool target_stack_preserved = false;
+    bool bootstrap_started = false;
+    bool thread_start_requested = false;
+    bool pthread_create_ok = false;
+    bool detached = false;
+    bool trace_continue_seen = false;
+    bool trace_stop_seen = false;
+    int pthread_create_rc = -1;
+    unsigned imports_resolved = 0;
+    unsigned imports_unresolved = 0;
+    const char* first_unresolved = nullptr;
+};
+
+/*
+ * Reconstruct the hardware-proven v0.28b loader contract:
+ *
+ *   debugger auth -> one PT_ATTACH -> ELF map -> full payload args
+ *   -> remote pthread_create -> PT_DETACH(0) -> restore original auth
+ *
+ * The controller never replaces a live ShellUI thread with the payload entry.
+ */
+[[nodiscard]] StableInjectionResult inject_shellui_stable(
+    pid_t shellui_pid,
+    const std::uint8_t* renderer_elf,
+    std::size_t renderer_size,
+    StableInjectionMode mode =
+        StableInjectionMode::StartRendererThread) noexcept;
+
+} // namespace common_fps::ps5

--- a/tests/test_core.cpp
+++ b/tests/test_core.cpp
@@ -165,6 +165,11 @@ static void test_exact_counter_algorithm_and_lifecycle() {
     f = life.tick();
     assert(f.loading);
 
+    // Hardware-proven sampler discards the first complete delta as warmup.
+    p.advance(60, 1000);
+    f = life.tick();
+    assert(f.loading);
+
     // 60 frame increments during exactly one second -> 60.0 FPS.
     p.advance(60, 1000);
     f = life.tick();
@@ -193,6 +198,10 @@ static void test_exact_counter_algorithm_and_lifecycle() {
 
     f = life.tick();
     assert(f.loading); // new baseline
+
+    p.advance(30, 1000);
+    f = life.tick();
+    assert(f.loading); // discarded warmup delta
 
     p.advance(30, 1000);
     f = life.tick();
@@ -236,6 +245,10 @@ static void test_integer_only_fps() {
 
     // 596 frame increments over 10 seconds = 59.6 FPS internally.
     // Public/displayed result must be integer 60.
+    p.advance(596, 10000);
+    f = life.tick();
+    assert(f.loading); // discarded warmup delta
+
     p.advance(596, 10000);
     f = life.tick();
 

--- a/tools/embed_binary.py
+++ b/tools/embed_binary.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Embed a binary file as a C++ byte array for the PS5 controller."""
+
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} INPUT OUTPUT.cpp", file=sys.stderr)
+        return 2
+
+    src = Path(sys.argv[1])
+    dst = Path(sys.argv[2])
+    data = src.read_bytes()
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with dst.open("w", encoding="utf-8", newline="\n") as out:
+        out.write("#include <cstddef>\n#include <cstdint>\n\n")
+        out.write("extern const std::uint8_t commonfps_shellui_elf[] = {\n")
+        for offset in range(0, len(data), 16):
+            chunk = data[offset:offset + 16]
+            out.write("    ")
+            out.write(", ".join(f"0x{b:02x}" for b in chunk))
+            out.write(",\n")
+        out.write("};\n\n")
+        out.write(
+            f"extern const std::size_t commonfps_shellui_elf_size = {len(data)}u;\n"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_test20_repro.py
+++ b/tools/verify_test20_repro.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Verify the byte-exact PARITY TEST20 ELF and etaHEN plugin."""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import sys
+
+
+EXPECTED_ELF_SHA256 = (
+    "b791baf6f85063d0c7ec57eebcbf60116dff58dfc4ec74aa6d9dedcc1ecc32ef"
+)
+EXPECTED_PLUGIN_SHA256 = (
+    "7bdcc16cc582bd89c7f1680471436ef58fdc53bab159c7e36278a5e8f1c8fa49"
+)
+PLUGIN_HEADER = b"etaHEN_PLUGIN\0CFPS00039\0" + b"1.28\0"
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} TEST20.elf TEST20.plugin", file=sys.stderr)
+        return 2
+
+    elf_path = pathlib.Path(sys.argv[1])
+    plugin_path = pathlib.Path(sys.argv[2])
+    elf = elf_path.read_bytes()
+    plugin = plugin_path.read_bytes()
+
+    checks = [
+        (digest(elf) == EXPECTED_ELF_SHA256, "ELF SHA-256 mismatch"),
+        (digest(plugin) == EXPECTED_PLUGIN_SHA256, "plugin SHA-256 mismatch"),
+        (plugin.startswith(PLUGIN_HEADER), "plugin metadata mismatch"),
+        (plugin[len(PLUGIN_HEADER):] == elf, "plugin body differs from ELF"),
+        (b"PARITY TEST20 sampler-only no-recorder A/B" in elf,
+         "TEST20 marker missing"),
+        (b"renderer=disabled" in elf, "renderer-disabled marker missing"),
+    ]
+
+    failures = [message for ok, message in checks if not ok]
+    if failures:
+        for message in failures:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 1
+
+    print(f"verified ELF    {EXPECTED_ELF_SHA256}")
+    print(f"verified plugin {EXPECTED_PLUGIN_SHA256}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_test30_artifact.py
+++ b/tools/verify_test30_artifact.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Verify PARITY TEST30 metadata, payload identity and test boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import sys
+
+
+PLUGIN_HEADER = b"etaHEN_PLUGIN\0CFPS00049\0" + b"1.38\0"
+EXPECTED_ELF_SHA256 = (
+    "732db78e9329fcabbe93a66972e5d20e5137256769385138348cc88c45a99f9a"
+)
+EXPECTED_PLUGIN_SHA256 = (
+    "b766d1c479cf5720b723fa73caab442bece4048420ed371a70ba6378b49b9515"
+)
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} TEST30.elf TEST30.plugin", file=sys.stderr)
+        return 2
+
+    elf_path = pathlib.Path(sys.argv[1])
+    plugin_path = pathlib.Path(sys.argv[2])
+    elf = elf_path.read_bytes()
+    plugin = plugin_path.read_bytes()
+
+    checks = [
+        (digest(elf) == EXPECTED_ELF_SHA256, "ELF SHA-256 mismatch"),
+        (digest(plugin) == EXPECTED_PLUGIN_SHA256, "plugin SHA-256 mismatch"),
+        (plugin.startswith(PLUGIN_HEADER), "plugin metadata mismatch"),
+        (plugin[len(PLUGIN_HEADER):] == elf, "plugin body differs from ELF"),
+        (b"PARITY TEST30 tracked-process no-fork A/B" in elf,
+         "TEST30 marker missing"),
+        (b"internal_fork=absent" in elf, "no-fork marker missing"),
+        (b"renderer=disabled" in elf, "renderer-disabled marker missing"),
+        (b"CommonFPS_v110_test30_tracked_process.log" in elf,
+         "TEST30 log path missing"),
+        (b"PARITY TEST20 sampler-only no-recorder A/B" not in elf,
+         "stale TEST20 runtime marker present"),
+    ]
+
+    failures = [message for ok, message in checks if not ok]
+    if failures:
+        for message in failures:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 1
+
+    print(f"verified ELF    {EXPECTED_ELF_SHA256}")
+    print(f"verified plugin {EXPECTED_PLUGIN_SHA256}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_test31_artifact.py
+++ b/tools/verify_test31_artifact.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Verify PARITY TEST31 metadata and the tracked-renderer boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import sys
+
+
+PLUGIN_HEADER = b"etaHEN_PLUGIN\0CFPS00050\0" + b"1.39\0"
+
+# Reference hashes from the reproducible PS5 source build. Keeping the values
+# here makes later local/CI builds fail closed if the source or toolchain drifts.
+EXPECTED_ELF_SHA256 = (
+    "2db81cb2f896eb5310e22715226cc065e1b2c22304f6376c0fdbac5ce32b9f3a"
+)
+EXPECTED_PLUGIN_SHA256 = (
+    "fefdab4c49fc58eddfd798697d1479818367db67d6543f1994809d3002fcbc19"
+)
+EXPECTED_RENDERER_SHA256 = (
+    "7880aec891cb95cc860753d5a3fed1dfbb23caf526b6106275c3b2cc02b8e465"
+)
+RENDERER_SIZE = 70968
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: verify_test31_artifact.py TEST31.elf TEST31.plugin",
+            file=sys.stderr,
+        )
+        return 2
+
+    elf_path = pathlib.Path(sys.argv[1])
+    plugin_path = pathlib.Path(sys.argv[2])
+    elf = elf_path.read_bytes()
+    plugin = plugin_path.read_bytes()
+    elf_sha = digest(elf)
+    plugin_sha = digest(plugin)
+    renderer_offset = elf.find(b"\x7fELF", 1)
+    renderer = (
+        elf[renderer_offset : renderer_offset + RENDERER_SIZE]
+        if renderer_offset >= 0
+        else b""
+    )
+
+    checks = [
+        (
+            elf_sha == EXPECTED_ELF_SHA256,
+            "ELF SHA-256 mismatch",
+        ),
+        (
+            plugin_sha == EXPECTED_PLUGIN_SHA256,
+            "plugin SHA-256 mismatch",
+        ),
+        (plugin.startswith(PLUGIN_HEADER), "plugin metadata mismatch"),
+        (plugin[len(PLUGIN_HEADER) :] == elf, "plugin body differs from ELF"),
+        (
+            b"PARITY TEST31 tracked-process renderer A/B" in elf,
+            "TEST31 marker missing",
+        ),
+        (b"internal_fork=absent" in elf, "no-fork marker missing"),
+        (
+            b"renderer=shared_elf_etaHEN_update_hook" in elf,
+            "renderer marker missing",
+        ),
+        (b"injection=target_stack_pthread" in elf, "bootstrap marker missing"),
+        (b"ipc=udp_loopback_1s" in elf, "IPC marker missing"),
+        (b"mono_gc=pinned" in elf, "GC marker missing"),
+        (
+            b"CommonFPS_v110_test31_tracked_renderer.log" in elf,
+            "TEST31 log path missing",
+        ),
+        (b"id_commonfps_value" in elf, "embedded renderer missing"),
+        (
+            len(renderer) == RENDERER_SIZE
+            and digest(renderer) == EXPECTED_RENDERER_SHA256,
+            "embedded renderer hash mismatch",
+        ),
+        (
+            b"PARITY TEST30 tracked-process no-fork A/B" not in elf,
+            "stale TEST30 runtime marker present",
+        ),
+        (
+            b"PARITY TEST20 sampler-only no-recorder A/B" not in elf,
+            "stale TEST20 runtime marker present",
+        ),
+    ]
+
+    failures = [message for ok, message in checks if not ok]
+    if failures:
+        for message in failures:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 1
+
+    print(f"verified ELF    {elf_sha}")
+    print(f"verified plugin {plugin_sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
TEST31 has now passed the combined hardware gate on PS5 FW 9.60 with etaHEN 2.6:

- real on-screen FPS counter appeared in two games;
- first samples were 59 and 60 FPS;
- repeated normal system-menu restarts completed without an improper-shutdown warning;
- controller remains etaHEN-tracked with internal_fork=absent;
- renderer bootstrap completed with imports=35/0 and payload_size=70968.

The branch includes the reproducible source, TEST31 ELF/plugin build rules, verifier, SHA-256 manifest, and retained evidence log. The existing v1.0.0 release remains available as a rollback fallback. GitHub Actions host tests and PS5 source build are required before merge.